### PR TITLE
Don't re-run testing & linting on master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
   - docker
 
 stages:
-  - Test
+  - name: Test
+    if: type = pull_request
   - name: Push
     if: type = push AND branch = master
 


### PR DESCRIPTION
The code was already tested and linted in the PR build, so it's
redundant to run them again on the merge to master.