### PR TITLE
Add service lifetime context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module ship-it
 
 go 1.12
 
-require github.com/go-chi/chi v4.0.2+incompatible
+require (
+	github.com/go-chi/chi v4.0.2+incompatible
+	github.com/go-kit/kit v0.8.0
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
+github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,35 @@
 package main
 
 import (
+	"context"
 	"net/http"
+	"os"
+	"os/signal"
 	"ship-it/internal/api"
+	"syscall"
+
+	"github.com/go-kit/kit/log"
 )
 
 func main() {
-	http.ListenAndServe(":80", api.New())
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+	logger = log.With(logger, "timestamp", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+
+	logger.Log("event", "service.start")
+	defer logger.Log("event", "service.stop")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-signals
+		cancel()
+	}()
+
+	go http.ListenAndServe(":80", api.New())
+
+	<-ctx.Done()
+	logger.Log("event", "service.exit", "error", ctx.Err())
 }


### PR DESCRIPTION
Add a service context to control the lifetime of the service's
subsystems. Includes termination signal handling and logging.