### PR TITLE
VELO-1422: stub /releases endpoint

### DIFF
--- a/api/schema.json
+++ b/api/schema.json
@@ -26,7 +26,7 @@
           "build",
           "monitoring",
           "artifacts",
-          "deployment"
+          "status"
         ],
         "properties": {
           "name": {
@@ -144,7 +144,7 @@
                 "title": "The Travis Schema",
                 "default": "",
                 "examples": [
-                  ""
+                  "https://travis-ci.org/Wattpad/highlander/service"
                 ],
                 "pattern": "^(.*)$"
               }
@@ -275,92 +275,19 @@
               }
             }
           },
-          "deployment": {
-            "$id": "#/properties/items/items/properties/deployment",
-            "type": "object",
-            "title": "The Deployment Schema",
-            "required": [
-              "status",
-              "resources"
+          "status": {
+            "$id": "#/properties/items/items/properties/status",
+            "type": "string",
+            "title": "The Status Schema",
+            "default": "",
+            "examples": [
+              "deployed",
+              "failed",
+              "pending_rollback",
+              "pending_install",
+              "pending_upgrade"
             ],
-            "properties": {
-              "status": {
-                "$id": "#/properties/items/items/properties/deployment/properties/status",
-                "type": "string",
-                "title": "The Status Schema",
-                "default": "",
-                "examples": [
-                  "deploying"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "resources": {
-                "$id": "#/properties/items/items/properties/deployment/properties/resources",
-                "type": "array",
-                "title": "The Resources Schema",
-                "items": {
-                  "$id": "#/properties/items/items/properties/deployment/properties/resources/items",
-                  "type": "object",
-                  "title": "The Items Schema",
-                  "required": [
-                    "kind",
-                    "metadata",
-                    "replicas",
-                    "availableReplicas"
-                  ],
-                  "properties": {
-                    "kind": {
-                      "$id": "#/properties/items/items/properties/deployment/properties/resources/items/properties/kind",
-                      "type": "string",
-                      "title": "The Kind Schema",
-                      "default": "",
-                      "examples": [
-                        "Deployment"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "metadata": {
-                      "$id": "#/properties/items/items/properties/deployment/properties/resources/items/properties/metadata",
-                      "type": "object",
-                      "title": "The Metadata Schema",
-                      "required": [
-                        "name"
-                      ],
-                      "properties": {
-                        "name": {
-                          "$id": "#/properties/items/items/properties/deployment/properties/resources/items/properties/metadata/properties/name",
-                          "type": "string",
-                          "title": "The Name Schema",
-                          "default": "",
-                          "examples": [
-                            "homeslice"
-                          ],
-                          "pattern": "^(.*)$"
-                        }
-                      }
-                    },
-                    "replicas": {
-                      "$id": "#/properties/items/items/properties/deployment/properties/resources/items/properties/replicas",
-                      "type": "integer",
-                      "title": "The Replicas Schema",
-                      "default": 0,
-                      "examples": [
-                        1
-                      ]
-                    },
-                    "availableReplicas": {
-                      "$id": "#/properties/items/items/properties/deployment/properties/resources/items/properties/availableReplicas",
-                      "type": "integer",
-                      "title": "The Availablereplicas Schema",
-                      "default": 0,
-                      "examples": [
-                        1
-                      ]
-                    }
-                  }
-                }
-              }
-            }
+            "pattern": "^(.*)$"
           }
         }
       }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190607181551-461777fb6f67 // indirect
 	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/Wattpad/sqsconsumer v0.0.0-20190611184259-511082fa45b3
 	github.com/aws/aws-sdk-go v1.19.47
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
@@ -14,4 +15,5 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190607181551-461777fb6f67 // indirect
+	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/aws/aws-sdk-go v1.19.47 h1:ZEze0mpk8Fttrsz6UNLqhH/jRGYbMPfWFA2ILas4Am
 github.com/aws/aws-sdk-go v1.19.47/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
@@ -27,6 +29,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190607181551-461777fb6f67 h1:rJJxsykSlULwd2P2+pg/rtnwN2FrWp4IuCxOSyS0V00=
@@ -35,4 +38,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db h1:6/JqlYfC1CCaLnGceQTI+sDGhC9UBSPAsBqI0Gun6kU=
+golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/internal/api/controller.go
+++ b/internal/api/controller.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+)
+
+type controller struct {
+	svc Service
+}
+
+func newController(s Service) *controller {
+	return &controller{
+		svc: s,
+	}
+}
+
+func (c *controller) ListDeployments(w http.ResponseWriter, r *http.Request) {
+	deps, err := c.svc.ListDeployments(r.Context())
+	if err != nil {
+		Error500(w, err)
+		return
+	}
+
+	Success200(w, deps)
+}

--- a/internal/api/controller.go
+++ b/internal/api/controller.go
@@ -14,8 +14,8 @@ func newController(s Service) *controller {
 	}
 }
 
-func (c *controller) ListDeployments(w http.ResponseWriter, r *http.Request) {
-	deps, err := c.svc.ListDeployments(r.Context())
+func (c *controller) ListReleases(w http.ResponseWriter, r *http.Request) {
+	deps, err := c.svc.ListReleases(r.Context())
 	if err != nil {
 		Error500(w, err)
 		return

--- a/internal/api/controller_test.go
+++ b/internal/api/controller_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"ship-it/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockService struct {
+	mock.Mock
+}
+
+func (m *mockService) ListReleases(ctx context.Context) ([]models.Release, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.Release), args.Error(1)
+}
+
+func TestListReleasesReturns500ForInternalError(t *testing.T) {
+	mock := new(mockService)
+	mock.On("ListReleases", context.Background()).Return([]models.Release{}, errors.New("internal error"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/releases", nil)
+
+	c := newController(mock)
+	c.ListReleases(rec, req)
+
+	mock.AssertExpectations(t)
+	assert.Equal(t, rec.Code, http.StatusInternalServerError)
+}
+
+func TestListReleasesReturns200OnSuccess(t *testing.T) {
+	mock := new(mockService)
+	mock.On("ListReleases", context.Background()).Return([]models.Release{}, nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/releases", nil)
+
+	c := newController(mock)
+	c.ListReleases(rec, req)
+
+	mock.AssertExpectations(t)
+	assert.Equal(t, rec.Code, http.StatusOK)
+}

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func Success200(w http.ResponseWriter, v interface{}) error {
+	return jsonWrite(w, v, http.StatusOK)
+}
+
+func jsonWrite(w http.ResponseWriter, v interface{}, code int) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	return json.NewEncoder(w).Encode(v)
+}
+
+// Error is a structured JSON error response from the API
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func NewError(code int, err error) Error {
+	return Error{
+		Code:    code,
+		Message: err.Error(),
+	}
+}
+
+func ErrorJSON(w http.ResponseWriter, err Error) error {
+	return jsonWrite(w, err, err.Code)
+}
+
+func Error400(w http.ResponseWriter, err error) error {
+	return ErrorJSON(w, NewError(http.StatusBadRequest, err))
+}
+
+func Error404(w http.ResponseWriter, err error) error {
+	return ErrorJSON(w, NewError(http.StatusNotFound, err))
+}
+
+func Error500(w http.ResponseWriter, err error) error {
+	return ErrorJSON(w, NewError(http.StatusInternalServerError, err))
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,7 +14,7 @@ func health(w http.ResponseWriter, _ *http.Request) {
 }
 
 type Service interface {
-	ListDeployments(context.Context) ([]models.DeploymentDetail, error)
+	ListReleases(context.Context) ([]models.Release, error)
 }
 
 // New returns an 'http.Handler' that serves the ship-it API.
@@ -25,7 +25,7 @@ func New(s Service) http.Handler {
 
 	r.Get("/health", health)
 
-	r.Get("/deployments", c.ListDeployments)
+	r.Get("/releases", c.ListReleases)
 
 	r.Mount("/dashboard", http.FileServer(http.Dir("")))
 	r.Mount("/static", http.FileServer(http.Dir("dashboard")))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"context"
 	"net/http"
+
+	"ship-it/internal/models"
 
 	"github.com/go-chi/chi"
 )
@@ -10,11 +13,19 @@ func health(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+type Service interface {
+	ListDeployments(context.Context) ([]models.DeploymentDetail, error)
+}
+
 // New returns an 'http.Handler' that serves the ship-it API.
-func New() http.Handler {
+func New(s Service) http.Handler {
+	c := newController(s)
+
 	r := chi.NewRouter()
 
 	r.Get("/health", health)
+
+	r.Get("/deployments", c.ListDeployments)
 
 	r.Mount("/dashboard", http.FileServer(http.Dir("")))
 	r.Mount("/static", http.FileServer(http.Dir("dashboard")))

--- a/internal/models/deployment_detail.go
+++ b/internal/models/deployment_detail.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"time"
+)
+
+type DeploymentDetail struct {
+	Name         string    `json:"name"`
+	Created      string    `json:"created"`
+	LastDeployed time.Time `json:"lastDeployed"`
+	Owner        struct {
+		Team  string `json:"team"`
+		Slack string `json:"slack"`
+	} `json:"owner"`
+	AutoDeploy bool `json:"autoDeploy"`
+	Code       struct {
+		Github string `json:"github"`
+		Ref    string `json:"ref"`
+	} `json:"code"`
+	Build struct {
+		Travis string `json:"travis"`
+	} `json:"build"`
+	Monitoring struct {
+		Datadog struct {
+			Dashboard string `json:"dashboard"`
+			Monitors  string `json:"monitors"`
+		} `json:"datadog"`
+		Sumologic string `json:"sumologic"`
+	} `json:"monitoring"`
+	Artifacts struct {
+		Docker struct {
+			Image string `json:"image"`
+			Tag   string `json:"tag"`
+		} `json:"docker"`
+		Chart struct {
+			Path    string `json:"path"`
+			Version string `json:"version"`
+		} `json:"chart"`
+	} `json:"artifacts"`
+	Deployment struct {
+		Status string `json:"status"`
+	} `json:"deployment"`
+}

--- a/internal/models/release.go
+++ b/internal/models/release.go
@@ -4,12 +4,12 @@ import (
 	"time"
 )
 
-type DeploymentDetail struct {
+type Release struct {
 	Name         string    `json:"name"`
 	Created      string    `json:"created"`
 	LastDeployed time.Time `json:"lastDeployed"`
 	Owner        struct {
-		Team  string `json:"team"`
+		Squad string `json:"squad"`
 		Slack string `json:"slack"`
 	} `json:"owner"`
 	AutoDeploy bool `json:"autoDeploy"`
@@ -37,7 +37,5 @@ type DeploymentDetail struct {
 			Version string `json:"version"`
 		} `json:"chart"`
 	} `json:"artifacts"`
-	Deployment struct {
-		Status string `json:"status"`
-	} `json:"deployment"`
+	Status string `json:"status"`
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"ship-it/internal/models"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+func New() *Service {
+	return &Service{}
+}
+
+type Service struct{}
+
+func (s *Service) ListDeployments(ctx context.Context) ([]models.DeploymentDetail, error) {
+	return nil, ErrNotImplemented
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -15,6 +15,6 @@ func New() *Service {
 
 type Service struct{}
 
-func (s *Service) ListDeployments(ctx context.Context) ([]models.DeploymentDetail, error) {
+func (s *Service) ListReleases(ctx context.Context) ([]models.Release, error) {
 	return nil, ErrNotImplemented
 }

--- a/main.go
+++ b/main.go
@@ -5,14 +5,15 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"ship-it/internal/api"
-	"ship-it/internal/ecrconsumer"
 	"syscall"
 	"time"
 
+	"ship-it/internal/api"
+	"ship-it/internal/ecrconsumer"
+	"ship-it/internal/service"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/dogstatsd"
 )
@@ -60,7 +61,7 @@ func main() {
 
 	srv := http.Server{
 		Addr:    ":" + envConf.ServicePort,
-		Handler: api.New(),
+		Handler: api.New(service.New()),
 	}
 
 	exit := make(chan error)


### PR DESCRIPTION
The /releases endpoint will return a list of deployment details for
each service registered with ship-it.

---

To test locally:
```
$ make build
$ aws-vault exec wattpad -- make run
```

Then make a request to `$(docker-machine ip):8080/releases`. The business logic is stubbed out, so this returns `{"code":500,"message":"not implemented"}`