### PR TITLE
Add run makefile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY web .
 RUN npm install react-scripts && npm run build
 
 FROM alpine:3.8
+RUN apk add --no-cache ca-certificates
 COPY --from=golang-build /build/ship-it /
 COPY --from=node-build /build /dashboard
 CMD ["/ship-it"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build push
+.PHONY: build push run
 
 ECR_REGISTRY := 723255503624.dkr.ecr.us-east-1.amazonaws.com
 PROJECT_NAME := ship-it
@@ -15,3 +15,14 @@ push: build
 	docker tag $(IMAGE) $(ECR_REGISTRY)/$(LATEST_IMAGE)
 	docker push $(ECR_REGISTRY)/$(IMAGE)
 	docker push $(ECR_REGISTRY)/$(LATEST_IMAGE)
+
+run: build
+	docker run -p 8080:80 \
+	    -e AWS_REGION="us-east-1" \
+	    -e QUEUE_NAME="foo" \
+	    -e DOGSTATSD_HOST="localhost" \
+	    -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+	    -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+	    -e AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN} \
+	    -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+	    $(shell docker images -q $(PROJECT_NAME) | head -n 1)


### PR DESCRIPTION
The target runs the most recently built "ship-it "docker container with
AWS env credentials. It's intended to be used with aws-vault, ie.
`aws-vault exec wattpad -- make run`

In the future, this will likely be replaced by kubernetes deployment
manifests (helm chart), but it's useful for early development in the
meanwhile.