### PR TITLE
Reorganize API routes

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,10 +25,11 @@ func New(s Service) http.Handler {
 
 	r.Get("/health", health)
 
-	r.Get("/releases", c.ListReleases)
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/releases", c.ListReleases)
+	})
 
-	r.Mount("/dashboard", http.FileServer(http.Dir("")))
-	r.Mount("/static", http.FileServer(http.Dir("dashboard")))
+	r.Mount("/", http.FileServer(http.Dir("dashboard")))
 
 	return r
 }


### PR DESCRIPTION
The UI is now served from the root `/`, instead of `/dashboard`. The API
endpoints are served from the `/api` prefix.