### PR TITLE
Add structs matching the HelmRelease custom resource

### DIFF
--- a/internal/helmrelease/helmrelease.go
+++ b/internal/helmrelease/helmrelease.go
@@ -1,0 +1,41 @@
+package helmrelease
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// HelmReleaseSpec defines the desired state of HelmRelease
+type HelmReleaseSpec struct {
+	ReleaseName string                          `json:"releaseName"`
+	Chart       ChartSpec                       `json:"chart"`
+	Values      map[string]runtime.Unstructured `json:"values"`
+}
+
+// HelmReleaseSpec defines the desired Helm chart
+type ChartSpec struct {
+	Repository string `json:"repository"`
+	Path       string `json:"path"`
+	Revision   string `json:"revision"`
+}
+
+// HelmReleaseStatus defines the observed state of HelmRelease
+type HelmReleaseStatus struct {
+	// TODO
+}
+
+// HelmRelease is the Schema for the helmreleases API
+type HelmRelease struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   HelmReleaseSpec   `json:"spec,omitempty"`
+	Status HelmReleaseStatus `json:"status,omitempty"`
+}
+
+// HelmReleaseList contains a list of HelmRelease
+type HelmReleaseList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HelmRelease `json:"items"`
+}


### PR DESCRIPTION
These structs live in their own package so they can be easily shared,
since every component of ship-it will depend on it.

---

based off https://github.com/Wattpad/ship-it/blob/master/deploy/v1alpha1_helmrelease_crd.yaml