### PR TITLE
VELO-1457: lister integration

### DIFF
--- a/cmd/ship-it-api/main.go
+++ b/cmd/ship-it-api/main.go
@@ -43,7 +43,7 @@ func main() {
 	dd := dogstatsd.New("wattpad.ship-it.", logger)
 	go dd.SendLoop(time.Tick(time.Second), "udp", cfg.DataDogAddress())
 
-	k8s, err := k8s.New(ctx)
+	k8s, err := k8s.New(ctx, cfg.HelmReleasesResync())
 	if err != nil {
 		logger.Log("error", err)
 		os.Exit(1)

--- a/cmd/ship-it-api/main.go
+++ b/cmd/ship-it-api/main.go
@@ -43,7 +43,7 @@ func main() {
 	dd := dogstatsd.New("wattpad.ship-it.", logger)
 	go dd.SendLoop(time.Tick(time.Second), "udp", cfg.DataDogAddress())
 
-	k8s, err := k8s.New()
+	k8s, err := k8s.New(ctx)
 	if err != nil {
 		logger.Log("error", err)
 		os.Exit(1)

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -13,11 +14,17 @@ type Config struct {
 	ServicePort   string `split_words:"true" default:"80"`
 	GithubToken   string `split_words:"true" required:"true"`
 	GithubOrg     string `split_words:"true" required:"true"`
+
+	HelmReleasesResyncSeconds int64 `split_words:"true" default:"30"`
 }
 
 // DataDogAddress returns the local address of the datadog agent.
 func (c *Config) DataDogAddress() string {
 	return net.JoinHostPort(c.DogstatsdHost, c.DogstatsdPort)
+}
+
+func (c *Config) HelmReleasesResync() time.Duration {
+	return time.Duration(c.HelmReleasesResyncSeconds) * time.Second
 }
 
 // FromEnv returns a config using environment values.

--- a/internal/api/integrations/k8s/k8s.go
+++ b/internal/api/integrations/k8s/k8s.go
@@ -10,7 +10,7 @@ import (
 )
 
 type K8sClient struct {
-	helmreleases v1alpha1.HelmreleasesV1alpha1Interface
+	helmreleases v1alpha1.HelmReleasesGetter
 }
 
 func New() (*K8sClient, error) {
@@ -33,7 +33,7 @@ func (k *K8sClient) ListAll(namespace string) ([]models.Release, error) {
 		return nil, err
 	}
 
-	var releases []models.Release
+	releases := make([]models.Release, 0, len(releaseList.Items))
 	for _, r := range releaseList.Items {
 		releases = append(releases, models.Release{
 			Name:    r.GetName(),

--- a/internal/api/integrations/k8s/k8s.go
+++ b/internal/api/integrations/k8s/k8s.go
@@ -9,23 +9,6 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func (k *K8sClient) ListAll(namespace string) ([]models.Release, error) {
-	releaseList, err := k.helmreleases.HelmReleases(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var releases []models.Release
-	for _, r := range releaseList.Items {
-		releases = append(releases, models.Release{
-			Name:    r.GetName(),
-			Created: r.GetCreationTimestamp().Time,
-		})
-	}
-
-	return releases, nil
-}
-
 type K8sClient struct {
 	helmreleases v1alpha1.HelmreleasesV1alpha1Interface
 }
@@ -42,4 +25,21 @@ func New() (*K8sClient, error) {
 	}
 
 	return &K8sClient{client}, nil
+}
+
+func (k *K8sClient) ListAll(namespace string) ([]models.Release, error) {
+	releaseList, err := k.helmreleases.HelmReleases(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var releases []models.Release
+	for _, r := range releaseList.Items {
+		releases = append(releases, models.Release{
+			Name:    r.GetName(),
+			Created: r.GetCreationTimestamp().Time,
+		})
+	}
+
+	return releases, nil
 }

--- a/internal/api/integrations/k8s/k8s.go
+++ b/internal/api/integrations/k8s/k8s.go
@@ -19,7 +19,7 @@ type K8sClient struct {
 	lister v1alpha1.HelmReleaseLister
 }
 
-func New(ctx context.Context) (*K8sClient, error) {
+func New(ctx context.Context, resync time.Duration) (*K8sClient, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func New(ctx context.Context) (*K8sClient, error) {
 		exit <- struct{}{}
 	}()
 
-	factory := informers.NewSharedInformerFactory(client, 30*time.Second)
+	factory := informers.NewSharedInformerFactory(client, resync)
 	factory.Start(exit)
 
 	return &K8sClient{


### PR DESCRIPTION
This PR updates the API's k8s integration to use the generated HelmReleases informer instead of querying config maps.

---
This is still untested, but the code changes are pretty simple. I should test this out in minikube. 