### PR TITLE
VELO-1475: syncd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       name: Docker
       script:
         - TARGET=ship-it-api make build
-        - TARGET=ship-it-ecrconsumer make build
+        - TARGET=ship-it-syncd make build
 
     - stage: Test
       name: Go

--- a/cmd/ship-it-ecrconsumer/Dockerfile
+++ b/cmd/ship-it-ecrconsumer/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.12 AS golang-build
-WORKDIR /build
-COPY . .
-RUN CGO_ENABLED=0 go build -mod=vendor -o ship-it-ecrconsumer cmd/ship-it-ecrconsumer/main.go
-
-FROM alpine:3.8
-RUN apk add --no-cache ca-certificates
-COPY --from=golang-build /build/ship-it-ecrconsumer /
-CMD ["/ship-it-ecrconsumer"]

--- a/cmd/ship-it-syncd/Dockerfile
+++ b/cmd/ship-it-syncd/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.12 AS golang-build
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=0 go build -mod=vendor -o ship-it-syncd cmd/ship-it-syncd/main.go
+
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates
+COPY --from=golang-build /build/ship-it-syncd /
+CMD ["/ship-it-syncd"]

--- a/cmd/ship-it-syncd/main.go
+++ b/cmd/ship-it-syncd/main.go
@@ -7,11 +7,9 @@ import (
 	"syscall"
 	"time"
 
-	"ship-it/internal/ecrconsumer"
-	"ship-it/internal/ecrconsumer/config"
+	"ship-it/internal/syncd"
+	"ship-it/internal/syncd/config"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/dogstatsd"
 )
@@ -42,17 +40,11 @@ func main() {
 	dd := dogstatsd.New("wattpad.ship-it.", logger)
 	go dd.SendLoop(time.Tick(time.Second), "udp", cfg.DataDogAddress())
 
-	s, err := session.NewSession(cfg.AWS())
-	if err != nil {
+	// TODO: Allow configurable image/chart sync implementations. For now
+	// we'll just use our specific ecr+sqs/github+sqs implmentations.
+	syncd := syncd.New(nil, nil, nil, nil)
+	if err := syncd.Run(ctx); err != nil {
 		logger.Log("error", err)
 		os.Exit(1)
 	}
-
-	consumer, err := ecrconsumer.New(logger, dd.NewTiming("worker.time", 1.0).With("worker", "ecrconsumer", "queue", cfg.QueueName), cfg.QueueName, sqs.New(s))
-	if err != nil {
-		logger.Log("error", err)
-		os.Exit(1)
-	}
-
-	consumer.Run(ctx)
 }

--- a/internal/ecrconsumer/image_values.go
+++ b/internal/ecrconsumer/image_values.go
@@ -2,45 +2,17 @@ package ecrconsumer
 
 import (
 	"fmt"
-	"strings"
+
+	"ship-it/internal"
 
 	"ship-it/pkg/apis/k8s.wattpad.com/v1alpha1"
 )
-
-type Image struct {
-	Registry   string
-	Repository string
-	Tag        string
-}
-
-func parseImage(repo string, tag string) (*Image, error) {
-	arr := strings.Split(repo, "/")
-
-	var registry string
-	var repository string
-	if len(arr) == 2 {
-		repository = arr[1]
-		registry = arr[0]
-	} else {
-		return nil, fmt.Errorf("malformed repo: %s", repo)
-	}
-
-	return &Image{
-		Registry:   registry,
-		Repository: repository,
-		Tag:        tag,
-	}, nil
-}
-
-func (i Image) URI() string {
-	return i.Registry + "/" + i.Repository
-}
 
 func getImagePath(obj map[string]interface{}, serviceName string) []string {
 	for key, val := range obj {
 		if key == "image" {
 			if img, ok := val.(map[string]interface{}); ok {
-				image, err := parseImage(img["repository"].(string), img["tag"].(string))
+				image, err := internal.ParseImage(img["repository"].(string), img["tag"].(string))
 				if err != nil {
 					return []string{}
 				}
@@ -75,7 +47,7 @@ func table(vals map[string]interface{}, path []string) map[string]interface{} {
 	return tabled
 }
 
-func update(vals map[string]interface{}, img Image) {
+func update(vals map[string]interface{}, img internal.Image) {
 	path := getImagePath(vals, img.Repository)
 	if len(path) == 0 {
 		return
@@ -124,7 +96,7 @@ func cleanUpMapValue(v interface{}) interface{} {
 	}
 }
 
-func WithImage(img Image, r v1alpha1.HelmRelease) v1alpha1.HelmRelease {
+func WithImage(img internal.Image, r v1alpha1.HelmRelease) v1alpha1.HelmRelease {
 	copy := r.DeepCopy()
 
 	cleanMap := cleanUpStringMap(copy.Spec.Values)

--- a/internal/ecrconsumer/image_values_test.go
+++ b/internal/ecrconsumer/image_values_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 func TestGetImagePath(t *testing.T) {
-	var tests = []struct {
+	type testCase struct {
 		serviceName string
 		inputMap    map[string]interface{}
 		expected    []string
-	}{
-		{
+	}
+
+	testCases := map[string]testCase{
+		"nested image found": {
 			"bar",
 			map[string]interface{}{
 				"apples": "delicious",
@@ -30,7 +32,8 @@ func TestGetImagePath(t *testing.T) {
 				},
 			},
 			[]string{"oranges", "image"},
-		}, {
+		},
+		"un-nested image found": {
 			"bar",
 			map[string]interface{}{
 				"apples": "delicious",
@@ -40,7 +43,8 @@ func TestGetImagePath(t *testing.T) {
 				},
 			},
 			[]string{"image"},
-		}, {
+		},
+		"matches desired nested image": {
 			"bar",
 			map[string]interface{}{
 				"apples": "delicious",
@@ -57,7 +61,8 @@ func TestGetImagePath(t *testing.T) {
 				},
 			},
 			[]string{"oranges", "image"},
-		}, {
+		},
+		"matches desired un-nested image": {
 			"bar",
 			map[string]interface{}{
 				"apples": "delicious",
@@ -74,7 +79,8 @@ func TestGetImagePath(t *testing.T) {
 				},
 			},
 			[]string{"image"},
-		}, {
+		},
+		"desired image repo not found": {
 			"bar",
 			map[string]interface{}{
 				"apples": "delicious",
@@ -87,24 +93,14 @@ func TestGetImagePath(t *testing.T) {
 				},
 			},
 			[]string{},
-		}, {
-			"bar",
-			map[string]interface{}{
-				"apples": "delicious",
-				"oranges": map[string]interface{}{
-					"taste": "delicious",
-					"image": map[string]interface{}{
-						"repository": "foo",
-						"tag":        "baz",
-					},
-				},
-			},
-			[]string{},
 		},
 	}
-	for _, test := range tests {
-		output := getImagePath(test.inputMap, test.serviceName)
-		assert.Equal(t, test.expected, output)
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := getImagePath(test.inputMap, test.serviceName)
+			assert.Equal(t, test.expected, output)
+		})
 	}
 }
 

--- a/internal/ecrconsumer/image_values_test.go
+++ b/internal/ecrconsumer/image_values_test.go
@@ -3,6 +3,8 @@ package ecrconsumer
 import (
 	"testing"
 
+	"ship-it/internal"
+
 	"ship-it/pkg/apis/k8s.wattpad.com/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
@@ -156,12 +158,12 @@ func TestTable(t *testing.T) {
 
 func TestUpdateImage(t *testing.T) {
 	var tests = []struct {
-		newImage    Image
+		newImage    internal.Image
 		inputMap    map[string]interface{}
 		expectedMap map[string]interface{}
 	}{
 		{
-			Image{
+			internal.Image{
 				Registry:   "foo",
 				Repository: "bar",
 				Tag:        "newTag",
@@ -187,7 +189,7 @@ func TestUpdateImage(t *testing.T) {
 				},
 			},
 		}, {
-			Image{
+			internal.Image{
 				Registry:   "foo",
 				Repository: "bar",
 				Tag:        "newTag",
@@ -213,7 +215,7 @@ func TestUpdateImage(t *testing.T) {
 				},
 			},
 		}, {
-			Image{
+			internal.Image{
 				Registry:   "foo",
 				Repository: "bar",
 				Tag:        "newTag",
@@ -235,32 +237,6 @@ func TestUpdateImage(t *testing.T) {
 	for _, test := range tests {
 		update(test.inputMap, test.newImage)
 		assert.Equal(t, test.expectedMap, test.inputMap)
-	}
-}
-
-func TestParseImage(t *testing.T) {
-	var tests = []struct {
-		repo     string
-		tag      string
-		expected *Image
-	}{
-		{
-			"foo/bar",
-			"baz",
-			&Image{
-				Registry:   "foo",
-				Repository: "bar",
-				Tag:        "baz",
-			},
-		}, {
-			"foo-bar",
-			"baz",
-			nil,
-		},
-	}
-	for _, test := range tests {
-		img, _ := parseImage(test.repo, test.tag)
-		assert.Equal(t, test.expected, img)
 	}
 }
 
@@ -290,7 +266,7 @@ func TestWithImage(t *testing.T) {
 	}
 
 	t.Run("Matching Image Case", func(t *testing.T) {
-		expectedImg := Image{
+		expectedImg := internal.Image{
 			Registry:   "bar",
 			Repository: "foo",
 			Tag:        "new-tag",
@@ -303,7 +279,7 @@ func TestWithImage(t *testing.T) {
 
 	// Test No Matching Image Case
 	t.Run("No Matching Image Case", func(t *testing.T) {
-		expectedImg := Image{
+		expectedImg := internal.Image{
 			Registry:   "bar",
 			Repository: "oof",
 			Tag:        "new-tag",

--- a/internal/image.go
+++ b/internal/image.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Image struct {
+	Registry   string
+	Repository string
+	Tag        string
+}
+
+func (i Image) URI() string {
+	return i.Registry + "/" + i.Repository
+}
+
+func ParseImage(repo string, tag string) (*Image, error) {
+	arr := strings.Split(repo, "/")
+	if len(arr) != 2 {
+		return nil, fmt.Errorf("malformed repo: %s", repo)
+	}
+
+	return &Image{
+		Registry:   arr[0],
+		Repository: arr[1],
+		Tag:        tag,
+	}, nil
+}

--- a/internal/image_test.go
+++ b/internal/image_test.go
@@ -7,12 +7,14 @@ import (
 )
 
 func TestParseImage(t *testing.T) {
-	var tests = []struct {
+	type testCase struct {
 		repo     string
 		tag      string
 		expected *Image
-	}{
-		{
+	}
+
+	testCases := map[string]testCase{
+		"valid image": {
 			"foo/bar",
 			"baz",
 			&Image{
@@ -20,14 +22,18 @@ func TestParseImage(t *testing.T) {
 				Repository: "bar",
 				Tag:        "baz",
 			},
-		}, {
+		},
+		"invalid image": {
 			"foo-bar",
 			"baz",
 			nil,
 		},
 	}
-	for _, test := range tests {
-		img, _ := ParseImage(test.repo, test.tag)
-		assert.Equal(t, test.expected, img)
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			img, _ := ParseImage(test.repo, test.tag)
+			assert.Equal(t, test.expected, img)
+		})
 	}
 }

--- a/internal/image_test.go
+++ b/internal/image_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImage(t *testing.T) {
+	var tests = []struct {
+		repo     string
+		tag      string
+		expected *Image
+	}{
+		{
+			"foo/bar",
+			"baz",
+			&Image{
+				Registry:   "foo",
+				Repository: "bar",
+				Tag:        "baz",
+			},
+		}, {
+			"foo-bar",
+			"baz",
+			nil,
+		},
+	}
+	for _, test := range tests {
+		img, _ := ParseImage(test.repo, test.tag)
+		assert.Equal(t, test.expected, img)
+	}
+}

--- a/internal/syncd/config/config.go
+++ b/internal/syncd/config/config.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"net"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// Config provides the service's configuration options.
+type Config struct {
+	AWSRegion          string `envconfig:"AWS_REGION" required:"true"`
+	DogstatsdHost      string `split_words:"true" required:"true"`
+	DogstatsdPort      string `split_words:"true" default:"8125"`
+	EcrQueue           string `split_words:"true" required:"true"`
+	GithubToken        string `split_words:"true" required:"true"`
+	GithubOrg          string `split_words:"true" required:"true"`
+	GithubQueue        string `split_words:"true" required:"true"`
+	Namespace          string `split_words:"true" required:"true"`
+	ReleaseName        string `split_words:"true" required:"true"`
+	HelmTimeoutSeconds int64  `split_words:"true" default:"10"`
+}
+
+// DataDogAddress returns the local address of the datadog agent.
+func (c *Config) DataDogAddress() string {
+	return net.JoinHostPort(c.DogstatsdHost, c.DogstatsdPort)
+}
+
+// AWS returns an AWS config using the service's config values.
+func (c *Config) AWS() *aws.Config {
+	return &aws.Config{
+		Region: aws.String(c.AWSRegion),
+	}
+}
+
+func (c *Config) HelmTimeout() time.Duration {
+	return time.Duration(c.HelmTimeoutSeconds) * time.Second
+}
+
+// FromEnv returns a config using environment values.
+func FromEnv() (*Config, error) {
+	env := new(Config)
+	if err := envconfig.Process("", env); err != nil {
+		return nil, err
+	}
+	return env, nil
+}

--- a/internal/syncd/multierror.go
+++ b/internal/syncd/multierror.go
@@ -1,0 +1,30 @@
+package syncd
+
+import (
+	"fmt"
+	"strings"
+)
+
+type multiError []error
+
+func (me *multiError) Add(err error) {
+	*me = append(*me, err)
+}
+
+func (me multiError) Error() string {
+	switch n := len(me); n {
+	case 0:
+		return ""
+	case 1:
+		return me[0].Error()
+	default:
+		msgs := make([]string, 0, n+1)
+
+		msgs = append(msgs, fmt.Sprintf("multiple errors (%d):", n))
+		for i, err := range me {
+			msgs = append(msgs, fmt.Sprintf("%d: %s", i+1, err.Error()))
+		}
+
+		return strings.Join(msgs, "\n\t")
+	}
+}

--- a/internal/syncd/multierror_test.go
+++ b/internal/syncd/multierror_test.go
@@ -1,0 +1,42 @@
+package syncd
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiErrorEmpty(t *testing.T) {
+	var me multiError
+	assert.EqualError(t, me, "")
+}
+
+func TestMultiErrorSingle(t *testing.T) {
+	errFoo := errors.New("foo")
+
+	var me multiError
+	me.Add(errFoo)
+
+	assert.EqualError(t, me, errFoo.Error())
+}
+
+func TestMultiErrorMultiple(t *testing.T) {
+	errFoo := errors.New("foo")
+	errBar := errors.New("bar")
+	errBaz := errors.New(`failed to baz:
+quux`)
+
+	var me multiError
+	me.Add(errFoo)
+	me.Add(errBar)
+	me.Add(errBaz)
+
+	expected := `multiple errors (3):
+	1: foo
+	2: bar
+	3: failed to baz:
+quux`
+
+	assert.EqualError(t, me, expected)
+}

--- a/internal/syncd/syncd.go
+++ b/internal/syncd/syncd.go
@@ -1,0 +1,89 @@
+package syncd
+
+import (
+	"context"
+	"sync"
+
+	"ship-it/internal"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
+)
+
+// ImageReconciler is a callback that reconciles a new image with some external
+// state. For example, updating the values of a helm chart in a remote
+// repository to use the new image's tag.
+type ImageReconciler interface {
+	Reconcile(context.Context, *internal.Image) error
+}
+
+// ImageListener models a stream of `*Image` events. It calls the
+// ImageReconciler to reconcile each new image with some external state.
+type ImageListener interface {
+	Listen(context.Context, ImageReconciler) error
+}
+
+// ChartReconciler is an callback that reconciles a new chart with some external
+// state. For example, deploying the chart to a kubernetes cluster.
+type ChartReconciler interface {
+	Reconcile(context.Context, *chart.Chart) error
+}
+
+// ChartListener models a stream of `*chart.Chart` events. It calls the
+// ChartReconciler to reconcile each new chart with some external state.
+type ChartListener interface {
+	Listen(context.Context, ChartReconciler) error
+}
+
+// Syncd facilitates background synchronization between an image registry, a
+// helm chart repository and some external state, like a kubernetes cluster.
+type Syncd struct {
+	chartListener   ChartListener
+	chartReconciler ChartReconciler
+
+	imageListener   ImageListener
+	imageReconciler ImageReconciler
+}
+
+func New(cl ChartListener, cr ChartReconciler, il ImageListener, ir ImageReconciler) *Syncd {
+	return &Syncd{
+		chartListener:   cl,
+		chartReconciler: cr,
+
+		imageListener:   il,
+		imageReconciler: ir,
+	}
+}
+
+func (s *Syncd) Run(ctx context.Context) error {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	errs := make(chan error, 2)
+
+	// cancel both listeners if either one exits
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		errs <- s.chartListener.Listen(ctx, s.chartReconciler)
+		wg.Done()
+		cancel()
+	}()
+
+	go func() {
+		errs <- s.imageListener.Listen(ctx, s.imageReconciler)
+		wg.Done()
+		cancel()
+	}()
+
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	var merr multiError
+	for err := range errs {
+		merr.Add(err)
+	}
+
+	return merr
+}

--- a/internal/syncd/syncd.go
+++ b/internal/syncd/syncd.go
@@ -9,42 +9,45 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-// ImageReconciler is a callback that reconciles a new image with some external
-// state. For example, updating the values of a helm chart in a remote
-// repository to use the new image's tag.
+// ImageReconciler is a callback that reconciles new service images with the
+// state of ship-it's service registry chart. For example, by updating the chart
+// in a remote repository to use the new image.
 type ImageReconciler interface {
 	Reconcile(context.Context, *internal.Image) error
 }
 
-// ImageListener models a stream of `*Image` events. It calls the
-// ImageReconciler to reconcile each new image with some external state.
+// ImageListener models a stream of `*Image` events for service images. It calls
+// the ImageReconciler to reconcile new images with ship-it's service registry
+// chart.
 type ImageListener interface {
 	Listen(context.Context, ImageReconciler) error
 }
 
-// ChartReconciler is an callback that reconciles a new chart with some external
-// state. For example, deploying the chart to a kubernetes cluster.
-type ChartReconciler interface {
+// RegistryChartReconciler is an callback that reconciles a new registry chart
+// with the kubernetes cluster state. For example, by deploying the chart to a
+// cluster.
+type RegistryChartReconciler interface {
 	Reconcile(context.Context, *chart.Chart) error
 }
 
-// ChartListener models a stream of `*chart.Chart` events. It calls the
-// ChartReconciler to reconcile each new chart with some external state.
-type ChartListener interface {
-	Listen(context.Context, ChartReconciler) error
+// RegistryChartListener models a stream of `*chart.Chart` events for ship-it's
+// service registry chart. It calls the RegistryChartReconciler to reconcile
+// each new chart with the kubernetes cluster state.
+type RegistryChartListener interface {
+	Listen(context.Context, RegistryChartReconciler) error
 }
 
-// Syncd facilitates background synchronization between an image registry, a
-// helm chart repository and some external state, like a kubernetes cluster.
+// Syncd facilitates background synchronization between a docker image registry,
+// ship-it's service registry helm chart, and kubernetes cluster state.
 type Syncd struct {
-	chartListener   ChartListener
-	chartReconciler ChartReconciler
+	chartListener   RegistryChartListener
+	chartReconciler RegistryChartReconciler
 
 	imageListener   ImageListener
 	imageReconciler ImageReconciler
 }
 
-func New(cl ChartListener, cr ChartReconciler, il ImageListener, ir ImageReconciler) *Syncd {
+func New(cl RegistryChartListener, cr RegistryChartReconciler, il ImageListener, ir ImageReconciler) *Syncd {
 	return &Syncd{
 		chartListener:   cl,
 		chartReconciler: cr,


### PR DESCRIPTION
This PR is in a bit of a weird state. It removes code we were using, like ecrconsumer in `cmd/ship-it-syncd/main.go` because that code needs to be updated to match the interfaces defined in `internal/syncd`. It adds code we're not using yet, like some of the config fields in `internal/syncd/config`, because we have blocked PRs depending on this code and I know the unused code will be used in those PRs.

The syncd package provides the image-registry/chart-repo/kube-cluster synchronization logic, but is abstracted to avoid being directly coupled to ECR+SQS/Github+SQS. We still need to think about how we'd choose between different implementations in a configurable way, but for now we can just hardcode our specific implementations. 

Also, I renamed it from `gitsync`, because if you look through the code in `internal/syncd/syncd.go`, there's no reference to git-anything, so it feels weird to be randomly mentioning git in the package name. `syncd` was the best I came up with, since I don't think it's a stretch to imagine it as a background synchronization process.