### PR TITLE
Remove Local API Address

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -6,8 +6,7 @@ import axios from 'axios';
 import { CircularProgress } from '@material-ui/core';
 import urljoin from 'url-join'
 
-const API_ADDRESS = urljoin(window.location.protocol + '//' + window.location.host, 'api') // Point to local IP for testing
-//const API_ADDRESS = 'http://localhost:8080/api'
+const API_ADDRESS = urljoin(window.location.protocol + '//' + window.location.host, 'api')
 class App extends React.Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
Skaffold can now be used to fully replicate production while testing the
web UI. As a result the address variable pointing to a mock local API is
no longer needed.