### PR TITLE
Add HelmValues method to HelmRelease type

### DIFF
--- a/internal/ecrconsumer/image_values.go
+++ b/internal/ecrconsumer/image_values.go
@@ -100,13 +100,7 @@ func cleanUpMapValue(v interface{}) interface{} {
 func WithImage(img internal.Image, r shipitv1beta1.HelmRelease) (shipitv1beta1.HelmRelease, error) {
 	copy := r.DeepCopy()
 
-	var values map[string]interface{}
-	err := json.Unmarshal(copy.Spec.Values.Raw, &values)
-	if err != nil {
-		return shipitv1beta1.HelmRelease{}, err
-	}
-
-	cleanMap := cleanUpStringMap(values)
+	cleanMap := cleanUpStringMap(r.HelmValues())
 	update(cleanMap, img)
 
 	newJSON, _ := json.Marshal(cleanMap)

--- a/internal/ecrconsumer/image_values_test.go
+++ b/internal/ecrconsumer/image_values_test.go
@@ -1,7 +1,6 @@
 package ecrconsumer
 
 import (
-	"encoding/json"
 	"testing"
 
 	"ship-it/internal"
@@ -273,7 +272,7 @@ func TestWithImage(t *testing.T) {
 		}
 		outputRls, err := WithImage(expectedImg, rls)
 		assert.NoError(t, err)
-		outputValues := getChartValues(outputRls)
+		outputValues := outputRls.HelmValues()
 
 		outputImg := outputValues["image"].(map[string]interface{})
 		assert.Equal(t, expectedImg.Tag, outputImg["tag"].(string))
@@ -288,16 +287,10 @@ func TestWithImage(t *testing.T) {
 		}
 		outputRls, err := WithImage(expectedImg, rls)
 		assert.NoError(t, err)
-		inputValues := getChartValues(rls)
-		outputValues := getChartValues(outputRls)
+		inputValues := rls.HelmValues()
+		outputValues := outputRls.HelmValues()
 		assert.Exactly(t, inputValues, outputValues)
 	})
-}
-
-func getChartValues(r shipitv1beta1.HelmRelease) map[string]interface{} {
-	var v map[string]interface{}
-	json.Unmarshal(r.Spec.Values.Raw, &v)
-	return v
 }
 
 func TestStringMapCleanup(t *testing.T) {

--- a/operator/api/v1beta1/helmrelease_types.go
+++ b/operator/api/v1beta1/helmrelease_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -56,6 +58,17 @@ type HelmRelease struct {
 
 	Spec   HelmReleaseSpec   `json:"spec,omitempty"`
 	Status HelmReleaseStatus `json:"status,omitempty"`
+}
+
+func (hr *HelmRelease) HelmValues() map[string]interface{} {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(hr.Spec.Values.Raw, &obj); err != nil {
+		// this is temporary until we're using a representation of the
+		// values that doesn't force us to handle this impossible error
+		return make(map[string]interface{})
+	}
+
+	return obj
 }
 
 // +kubebuilder:object:root=true

--- a/operator/api/v1beta1/helmrelease_types_test.go
+++ b/operator/api/v1beta1/helmrelease_types_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -84,6 +86,25 @@ var _ = Describe("HelmRelease", func() {
 			Expect(k8sClient.Get(context.TODO(), key, created)).ToNot(Succeed())
 		})
 
+	})
+
+	Context("Serializing Helm values", func() {
+		It("should unmarshal values as a JSON object", func() {
+			expectedVals := map[string]interface{}{"hello": "world"}
+
+			expectedRaw, _ := json.Marshal(expectedVals)
+
+			hr := HelmRelease{
+				Spec: HelmReleaseSpec{
+					Values: runtime.RawExtension{
+						Raw: expectedRaw,
+					},
+				},
+			}
+
+			By("calling HelmValues method")
+			Expect(hr.HelmValues()).To(Equal(expectedVals))
+		})
 	})
 
 })


### PR DESCRIPTION
Adding this method reduces code duplication and means that in the future
when we change the representation of the `Spec.Values` field, we'll only
need to update code in one place.