### PR TITLE
VELO-1492: Add high level reconcile logic

### DIFF
--- a/operator/controllers/helmrelease_controller.go
+++ b/operator/controllers/helmrelease_controller.go
@@ -23,6 +23,8 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/helm/pkg/helm"
+	"k8s.io/helm/pkg/proto/hapi/chart"
+	rls "k8s.io/helm/pkg/proto/hapi/services"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -31,15 +33,22 @@ import (
 
 var errNotImplemented = errors.New("not implemented")
 
+type HelmClient interface {
+	DeleteRelease(rlsName string, opts ...helm.DeleteOption) (*rls.UninstallReleaseResponse, error)
+	InstallReleaseFromChart(chart *chart.Chart, ns string, opts ...helm.InstallOption) (*rls.InstallReleaseResponse, error)
+	RollbackRelease(rlsName string, opts ...helm.RollbackOption) (*rls.RollbackReleaseResponse, error)
+	UpdateReleaseFromChart(rlsName string, chart *chart.Chart, opts ...helm.UpdateOption) (*rls.UpdateReleaseResponse, error)
+}
+
 // HelmReleaseReconciler reconciles a HelmRelease object
 type HelmReleaseReconciler struct {
 	client.Client
 	Log logr.Logger
 
-	helm *helm.Client
+	helm HelmClient
 }
 
-func NewHelmReleaseReconciler(l logr.Logger, client client.Client, helm *helm.Client) *HelmReleaseReconciler {
+func NewHelmReleaseReconciler(l logr.Logger, client client.Client, helm HelmClient) *HelmReleaseReconciler {
 	return &HelmReleaseReconciler{
 		Client: client,
 		Log:    l.WithName("controllers").WithName("HelmRelease"),

--- a/operator/controllers/helmrelease_controller.go
+++ b/operator/controllers/helmrelease_controller.go
@@ -17,19 +17,34 @@ package controllers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/helm/pkg/helm"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	shipitv1beta1 "ship-it-operator/api/v1beta1"
 )
 
+var errNotImplemented = errors.New("not implemented")
+
 // HelmReleaseReconciler reconciles a HelmRelease object
 type HelmReleaseReconciler struct {
 	client.Client
 	Log logr.Logger
+
+	helm *helm.Client
+}
+
+func NewHelmReleaseReconciler(l logr.Logger, client client.Client, helm *helm.Client) *HelmReleaseReconciler {
+	return &HelmReleaseReconciler{
+		Client: client,
+		Log:    l.WithName("controllers").WithName("HelmRelease"),
+		helm:   helm,
+	}
 }
 
 // +kubebuilder:rbac:groups=shipit.wattpad.com,resources=helmreleases,verbs=get;list;watch;create;update;patch;delete
@@ -44,19 +59,34 @@ func (r *HelmReleaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	if err := r.Get(ctx, req.NamespacedName, &helmRelease); err != nil {
 		if apierrs.IsNotFound(err) {
 			log.Info("HelmRelease doesn't exist")
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, r.onDelete(ctx, req.NamespacedName)
 		}
 
 		return ctrl.Result{}, err
 	}
 
-	log.Info("Make things happen", "test", helmRelease.Spec)
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.onUpdate(ctx, helmRelease)
 }
 
 func (r *HelmReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&shipitv1beta1.HelmRelease{}).
 		Complete(r)
+}
+
+func (r *HelmReleaseReconciler) onDelete(ctx context.Context, name types.NamespacedName) error {
+	// Update HelmRelease Status to 'PENDING_DELETE' -- but the HelmRelease doesn't exist anymore :(
+	// Delete the release with helm
+	return errNotImplemented
+}
+
+func (r *HelmReleaseReconciler) onUpdate(ctx context.Context, rls shipitv1beta1.HelmRelease) error {
+	// Update HelmRelease Status to 'PENDING_INSTALL' or 'PENDING_UPGRADE'
+	// Attempt the install/upgrade with helm
+	// If it succeeded, set Status to 'DEPLOYED'
+	// Else, set Status to 'PENDING_ROLLBACK'
+	// Attempt the rollback with helm
+	// If it succeeded, set Status to 'DEPLOYED'
+	// Else, set Status to 'FAILED'
+	return errNotImplemented
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -24,6 +24,7 @@ import (
 	"ship-it-operator/controllers"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/helm/pkg/helm"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
@@ -60,11 +61,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = (&controllers.HelmReleaseReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("HelmRelease"),
-	}).SetupWithManager(mgr)
-	if err != nil {
+	reconciler := controllers.NewHelmReleaseReconciler(ctrl.Log, mgr.GetClient(), helm.NewClient())
+
+	setupLog.Info("setting up HelmRelease controller")
+	if err := reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HelmRelease")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Create the HelmReleaseReconciler with a helm client so it can reconcile
HelmRelease events by modifying releases. Two method stubs are added to
handle reconciling deleted and updated HelmReleases.

VELO-1492