### PR TITLE
Correct Queue Names in Ship-it Chart Values

### DIFF
--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -27,8 +27,8 @@ syncd:
     tag: latest
     pullPolicy: IfNotPresent
 
-  ecrQueue: https://sqs.us-east-1.amazonaws.com/723255503624/ship-it-ecr.fifo
-  githubQueue: https://sqs.us-east-1.amazonaws.com/723255503624/ship-it-github.fifo
+  ecrQueue: ship-it-ecr.fifo
+  githubQueue: ship-it-github.fifo
 
   namespace: default
 


### PR DESCRIPTION
VELO-1529

The AWS SDK does not accept the full URI as a valid queue name. As a result, I have changed the queue name environment variables to have just the name and nothing else. If there is a place where we need the full identifier, I will add logic to parse out the name instead.