### PR TITLE
Add Missing Release Branch Variable to Syncd

### DIFF
--- a/deploy/ship-it/templates/syncd-deployment.yaml
+++ b/deploy/ship-it/templates/syncd-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: {{ .Values.syncd.ecrQueue }}
             - name: GITHUB_QUEUE
               value: {{ .Values.syncd.githubQueue }}
+            - name: RELEASE_BRANCH
+              value: {{ .Values.syncd.releaseBranch }}
           {{ if .Values.github }}
             - name: GITHUB_ORG
               value: {{ .Values.github.org }}

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -35,6 +35,7 @@ syncd:
   operationsRepository: miranda
 
   releaseName: ship-it-registry
+  releaseBranch: master
   registryChartPath: k8s/charts/components/ship-it-registry
 
   resources:


### PR DESCRIPTION
VELO-1529

The `RELEASE_BRANCH` environment variable which points ship-it to the
branch in miranda it should commit to was missing from the chart.