### PR TITLE
Fix Infinite Loop in ECR Queue Consumer

### DIFF
--- a/internal/syncd/integrations/ecr/listener.go
+++ b/internal/syncd/integrations/ecr/listener.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -71,7 +72,7 @@ func (l *ImageListener) handler(r syncd.ImageReconciler) sqsconsumer.MessageHand
 		}
 
 		if !validImageTagRegex.MatchString(ecrEvent.Tag) {
-			l.logger.Log("error", "invalid image tag, the image will be ignored")
+			l.logger.Log("error", fmt.Sprintf(`ignoring event for invalid image tag "%s" found in repo "%s"`, ecrEvent.Tag, ecrEvent.RepositoryName))
 			return nil
 		}
 

--- a/internal/syncd/integrations/ecr/listener.go
+++ b/internal/syncd/integrations/ecr/listener.go
@@ -3,7 +3,6 @@ package ecr
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"regexp"
 	"time"
 
@@ -72,7 +71,8 @@ func (l *ImageListener) handler(r syncd.ImageReconciler) sqsconsumer.MessageHand
 		}
 
 		if !validImageTagRegex.MatchString(ecrEvent.Tag) {
-			return fmt.Errorf("malformed image tag")
+			l.logger.Log("error", "invalid image tag, the image will be ignored")
+			return nil
 		}
 
 		return r.Reconcile(ctx, ecrEvent.Image())

--- a/internal/syncd/integrations/ecr/listener_test.go
+++ b/internal/syncd/integrations/ecr/listener_test.go
@@ -68,24 +68,13 @@ func TestECRHandler(t *testing.T) {
 	err := testListener.handler(mockReconciler)(context.Background(), `some bad message`)
 	assert.Error(t, err)
 
-	inputJSON := `
-{
-	"eventTime": "2019-07-11T14:19:59Z", 
-	"repositoryName": "monolith-php", 
-	"tag": "some invalid tag",
-	"registryId": "723255503624"
-}
-`
-	err = testListener.handler(mockReconciler)(context.Background(), inputJSON)
-	assert.Error(t, err)
-
 	mockReconciler.On("Reconcile", mock.Anything, &internal.Image{
 		Registry:   "723255503624.dkr.ecr.us-east-1.amazonaws.com",
 		Repository: "monolith-php",
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}).Return(error(nil))
 
-	inputJSON = `
+	inputJSON := `
 {
 	"eventTime": "2019-07-11T14:19:59Z", 
 	"repositoryName": "monolith-php", 


### PR DESCRIPTION
VELO-1529

The consumer returns an error when the image tag is not a valid commit
hash (ie. "latest"). The problem with this behaviour is that the SQS
consumer library believes the message has not been successfully
processed because the handler returned an error. As a result, the
invalid image is put back on the queue being processed over and over in an
endless loop. This PR has the handler return `nil` on these types of
images so they are removed from the queue. The invalid image tag error is still logged using the logger attached to the `ImageListener` type.