### PR TITLE
Fix Indexer Query

### DIFF
--- a/internal/syncd/integrations/ecr/reconciler.go
+++ b/internal/syncd/integrations/ecr/reconciler.go
@@ -14,7 +14,7 @@ type HelmReleaseEditor interface {
 }
 
 type IndexerService interface {
-	Lookup(repo string) ([]types.NamespacedName, error)
+	Lookup(image *internal.Image) ([]types.NamespacedName, error)
 }
 
 type ImageReconciler struct {
@@ -32,7 +32,7 @@ func NewReconciler(r HelmReleaseEditor, i IndexerService, l log.Logger) *ImageRe
 }
 
 func (r *ImageReconciler) Reconcile(ctx context.Context, image *internal.Image) error {
-	releases, err := r.indexer.Lookup(image.URI())
+	releases, err := r.indexer.Lookup(image)
 	if err != nil {
 		return errors.Wrapf(err, "failed to obtain the releases corresponding to the repository: %s", image.Repository)
 	}

--- a/internal/syncd/integrations/ecr/reconciler.go
+++ b/internal/syncd/integrations/ecr/reconciler.go
@@ -32,7 +32,7 @@ func NewReconciler(r HelmReleaseEditor, i IndexerService, l log.Logger) *ImageRe
 }
 
 func (r *ImageReconciler) Reconcile(ctx context.Context, image *internal.Image) error {
-	releases, err := r.indexer.Lookup(image.Repository)
+	releases, err := r.indexer.Lookup(image.URI())
 	if err != nil {
 		return errors.Wrapf(err, "failed to obtain the releases corresponding to the repository: %s", image.Repository)
 	}

--- a/internal/syncd/integrations/ecr/reconciler_test.go
+++ b/internal/syncd/integrations/ecr/reconciler_test.go
@@ -41,7 +41,7 @@ func TestReconcileLookupFailure(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", "bar").Return([]types.NamespacedName{}, fmt.Errorf("some error finding release"))
+	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{}, fmt.Errorf("some error finding release"))
 
 	err := reconciler.Reconcile(context.Background(), inputImage)
 
@@ -62,7 +62,7 @@ func TestReconcilerUpdateFailure(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", "bar").Return([]types.NamespacedName{
+	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{
 		{
 			Namespace: "default",
 			Name:      "bar",
@@ -90,7 +90,7 @@ func TestReconcilerSuccess(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", "bar").Return([]types.NamespacedName{
+	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{
 		{
 			Namespace: "default",
 			Name:      "bar",

--- a/internal/syncd/integrations/ecr/reconciler_test.go
+++ b/internal/syncd/integrations/ecr/reconciler_test.go
@@ -26,8 +26,8 @@ type MockIndexerService struct {
 	mock.Mock
 }
 
-func (m *MockIndexerService) Lookup(repo string) ([]types.NamespacedName, error) {
-	args := m.Called(repo)
+func (m *MockIndexerService) Lookup(image *internal.Image) ([]types.NamespacedName, error) {
+	args := m.Called(image)
 	return args.Get(0).([]types.NamespacedName), args.Error(1)
 }
 
@@ -41,7 +41,7 @@ func TestReconcileLookupFailure(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{}, fmt.Errorf("some error finding release"))
+	mockIndexService.On("Lookup", inputImage).Return([]types.NamespacedName{}, fmt.Errorf("some error finding release"))
 
 	err := reconciler.Reconcile(context.Background(), inputImage)
 
@@ -62,7 +62,7 @@ func TestReconcilerUpdateFailure(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{
+	mockIndexService.On("Lookup", inputImage).Return([]types.NamespacedName{
 		{
 			Namespace: "default",
 			Name:      "bar",
@@ -90,7 +90,7 @@ func TestReconcilerSuccess(t *testing.T) {
 		Tag:        "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	}
 
-	mockIndexService.On("Lookup", inputImage.URI()).Return([]types.NamespacedName{
+	mockIndexService.On("Lookup", inputImage).Return([]types.NamespacedName{
 		{
 			Namespace: "default",
 			Name:      "bar",

--- a/internal/syncd/integrations/k8s/informer.go
+++ b/internal/syncd/integrations/k8s/informer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	shipitv1beta1 "ship-it-operator/api/v1beta1"
+	"ship-it/internal"
 	"ship-it/internal/unstructured"
 
 	"github.com/pkg/errors"
@@ -81,11 +82,12 @@ func NewInformerWithCache(ctx context.Context, c cache.Cache) (*ImageRepositoryI
 }
 
 // Lookup returns the namespaced names of all releases that depend on the given
-// image repository.
-func (i *ImageRepositoryInformer) Lookup(repo string) ([]types.NamespacedName, error) {
-	objs, err := i.indexer.ByIndex(imageRepositoriesIndex, repo)
+// image repository URI.
+func (i *ImageRepositoryInformer) Lookup(image *internal.Image) ([]types.NamespacedName, error) {
+	URI := image.URI()
+	objs, err := i.indexer.ByIndex(imageRepositoriesIndex, URI)
 	if err != nil {
-		return nil, errors.Wrapf(err, "repository informer: failed to lookup releases for image repository \"%s\"", repo)
+		return nil, errors.Wrapf(err, "repository informer: failed to lookup releases for image repository \"%s\"", URI)
 	}
 
 	names := make([]types.NamespacedName, 0, len(objs))

--- a/internal/syncd/integrations/k8s/informer_test.go
+++ b/internal/syncd/integrations/k8s/informer_test.go
@@ -31,7 +31,7 @@ func TestLookup(t *testing.T) {
 	wordCountsRelease := "word-counts-release"
 
 	testImage := &internal.Image{
-		Registry:   "",
+		Registry:   "foo",
 		Repository: "word-counts-repo",
 		Tag:        "",
 	}

--- a/internal/syncd/integrations/k8s/informer_test.go
+++ b/internal/syncd/integrations/k8s/informer_test.go
@@ -3,11 +3,13 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"ship-it/internal"
 	"testing"
 
 	shipitv1beta1 "ship-it-operator/api/v1beta1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,31 +29,30 @@ func newFakeCache() *informertest.FakeInformers {
 func TestLookup(t *testing.T) {
 	helmReleaseKind := "HelmRelease"
 	wordCountsRelease := "word-counts-release"
-	wordCountsRepository := "word-counts-repo"
+
+	testImage := &internal.Image{
+		Registry:   "",
+		Repository: "word-counts-repo",
+		Tag:        "",
+	}
 
 	fakeCache := newFakeCache()
 
 	fakeInformer, err := fakeCache.FakeInformerForKind(shipitv1beta1.Kind(helmReleaseKind))
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	require.NoError(t, err)
 
 	informer, err := NewInformerWithCache(context.Background(), fakeCache)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	require.NoError(t, err)
 
 	values := map[string]interface{}{
 		"image": map[string]interface{}{
-			"repository": wordCountsRepository,
+			"repository": testImage.URI(),
 			"tag":        "foo",
 		},
 	}
 
 	valuesRaw, err := json.Marshal(values)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	require.NoError(t, err)
 
 	originalHR := &shipitv1beta1.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
@@ -76,7 +77,7 @@ func TestLookup(t *testing.T) {
 		Namespace: v1.NamespaceDefault,
 	}
 
-	names, err := informer.Lookup(wordCountsRepository)
+	names, err := informer.Lookup(testImage)
 	if assert.NoError(t, err) {
 		assert.Len(t, names, 1)
 		assert.Equal(t, names[0], expected)
@@ -92,7 +93,7 @@ func TestLookup(t *testing.T) {
 
 	fakeInformer.Update(originalHR, &updatedHR)
 
-	names, err = informer.Lookup(wordCountsRepository)
+	names, err = informer.Lookup(testImage)
 	if assert.NoError(t, err) {
 		assert.Len(t, names, 1)
 		assert.Equal(t, names[0], expected)
@@ -100,7 +101,7 @@ func TestLookup(t *testing.T) {
 
 	// delete the release
 	fakeInformer.Delete(&updatedHR)
-	names, err = informer.Lookup(wordCountsRepository)
+	names, err = informer.Lookup(testImage)
 	if assert.NoError(t, err) {
 		assert.Empty(t, names)
 	}


### PR DESCRIPTION
VELO-1529

The indexer takes the full repository URI as a key. This PR calls the
`URI()` method on the input image and passes it to the `Lookup` method.