### PR TITLE
Fix Tiller Connection Issue

### DIFF
--- a/cmd/ship-it-syncd/main.go
+++ b/cmd/ship-it-syncd/main.go
@@ -67,7 +67,7 @@ func main() {
 	imageReconciler := ecr.NewReconciler(gitClient, informer, logger)
 
 	chartReconciler := github.NewReconciler(
-		helm.NewClient(),
+		helm.NewClient(helm.Host(cfg.TillerHost)),
 		cfg.Namespace,
 		cfg.ReleaseName,
 		cfg.HelmTimeout(),

--- a/deploy/ship-it/templates/syncd-deployment.yaml
+++ b/deploy/ship-it/templates/syncd-deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: {{ .Values.syncd.githubQueue }}
             - name: RELEASE_BRANCH
               value: {{ .Values.syncd.releaseBranch }}
+            - name: TILLER_HOST
+              value: {{ .Values.syncd.tillerAddress }}
           {{ if .Values.github }}
             - name: GITHUB_ORG
               value: {{ .Values.github.org }}

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -30,6 +30,8 @@ syncd:
   ecrQueue: ship-it-ecr.fifo
   githubQueue: ship-it-github.fifo
 
+  tillerAddress: tiller-deploy.kube-system.svc.cluster.local:44134
+
   namespace: default
 
   operationsRepository: miranda

--- a/internal/syncd/config/config.go
+++ b/internal/syncd/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	RegistryChartPath    string `split_words:"true" required:"true"`
 	ReleaseBranch        string `split_words:"true" default:"master"`
 	OperationsRepository string `split_words:"true" required:"true"`
+	TillerHost           string `split_words:"true" required:"true"`
 }
 
 // DataDogAddress returns the local address of the datadog agent.


### PR DESCRIPTION
VELO-1529

When testing Ship-it in scal-labs, I discovered that that new releases
could not be installed due to a timing out connection to Tiller. The
default Tiller host used by the helm client is not the same as ours. This
PR adds an environment variable for the Tiller host and adds the value
as an option when creating the helm client.