### PR TITLE
Refactor chartdownloader & fixups

### DIFF
--- a/operator/chartdownloader/factory.go
+++ b/operator/chartdownloader/factory.go
@@ -9,15 +9,15 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-type Interface interface {
+type ChartDownloader interface {
 	Download(context.Context, string) (*chart.Chart, error)
 }
 
 type factory struct {
-	downloaders map[string]Interface
+	downloaders map[string]ChartDownloader
 }
 
-func New(downloaders map[string]Interface) Interface {
+func New(downloaders map[string]ChartDownloader) ChartDownloader {
 	return &factory{
 		downloaders: downloaders,
 	}

--- a/operator/chartdownloader/factory_test.go
+++ b/operator/chartdownloader/factory_test.go
@@ -1,34 +1,48 @@
 package chartdownloader
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
+
+type mockS3Downloader struct {
+	mock.Mock
+}
+
+func (m *mockS3Downloader) Download(ctx context.Context, chartURL string) (*chart.Chart, error) {
+	args := m.Called(ctx, chartURL)
+
+	var ret0 *chart.Chart
+	if args0 := args.Get(0); args0 != nil {
+		ret0 = args0.(*chart.Chart)
+	}
+
+	return ret0, args.Error(1)
+}
 
 func TestFactoryS3Provider(t *testing.T) {
 	bucket := "helm-charts"
-	repoURL := fmt.Sprintf("s3://wattpad.amazonaws.com/%s", bucket)
+	repoURL := fmt.Sprintf("s3://charts.wattpadhq.com/%s", bucket)
 
-	dl, err := New(repoURL, &ProviderFuncs{
-		S3Func: func() client.ConfigProvider {
-			return session.Must(session.NewSession())
-		},
+	mockS3 := new(mockS3Downloader)
+	mockS3.On("Download", mock.Anything, repoURL).Return(&chart.Chart{}, nil)
+
+	dl := New(map[string]Interface{
+		"s3": mockS3,
 	})
 
+	_, err := dl.Download(context.Background(), repoURL)
 	require.NoError(t, err)
-
-	s3, ok := dl.(*S3Downloader)
-	assert.True(t, ok)
-	assert.Equal(t, s3.Bucket, bucket)
 }
 
 func TestFactoryUnsupportedProvider(t *testing.T) {
 	repoURL := "git://github.com/Wattpad/foo"
-	_, err := New(repoURL, nil)
+	_, err := New(nil).Download(context.Background(), repoURL)
 	assert.Error(t, err)
 }

--- a/operator/chartdownloader/factory_test.go
+++ b/operator/chartdownloader/factory_test.go
@@ -33,7 +33,7 @@ func TestFactoryS3Provider(t *testing.T) {
 	mockS3 := new(mockS3Downloader)
 	mockS3.On("Download", mock.Anything, repoURL).Return(&chart.Chart{}, nil)
 
-	dl := New(map[string]Interface{
+	dl := New(map[string]ChartDownloader{
 		"s3": mockS3,
 	})
 

--- a/operator/chartdownloader/s3.go
+++ b/operator/chartdownloader/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,42 +15,50 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-type downloaderAPI interface {
+type S3DownloadManager interface {
 	DownloadWithContext(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error)
 }
 
 type S3Downloader struct {
-	Bucket string
-	d      downloaderAPI
+	manager S3DownloadManager
 }
 
-func newS3Downloader(bucketName string, dl downloaderAPI) *S3Downloader {
+func NewS3Downloader(manager S3DownloadManager) *S3Downloader {
 	return &S3Downloader{
-		Bucket: bucketName,
-		d:      dl,
+		manager: manager,
 	}
 }
 
-func (dl S3Downloader) download(ctx context.Context, key string) ([]byte, error) {
+func (dl S3Downloader) download(ctx context.Context, bucket, key string) ([]byte, error) {
 	buf := aws.NewWriteAtBuffer(nil)
 
-	_, err := dl.d.DownloadWithContext(ctx, buf, &s3.GetObjectInput{
-		Bucket: aws.String(dl.Bucket),
+	_, err := dl.manager.DownloadWithContext(ctx, buf, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
 
 	return buf.Bytes(), err
 }
 
-func makeS3Key(chartName string) string {
-	return "/" + strings.TrimPrefix(chartName, "/")
-}
-
-func (dl S3Downloader) Download(ctx context.Context, chartName string) (*chart.Chart, error) {
-	chartBytes, err := dl.download(ctx, makeS3Key(chartName))
+func (dl S3Downloader) Download(ctx context.Context, chartURL string) (*chart.Chart, error) {
+	bucket, object, err := parseBucketObject(chartURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to download chart %s", chartName)
+		return nil, errors.Wrapf(err, "failed to parse S3 bucket and object from URL %s", chartURL)
+	}
+
+	chartBytes, err := dl.download(ctx, bucket, object)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to download chart %s", chartURL)
 	}
 
 	return chartutil.LoadArchive(bytes.NewBuffer(chartBytes))
+}
+
+func parseBucketObject(rawChartURL string) (bucket string, object string, err error) {
+	chartURL, err := url.Parse(rawChartURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	return chartURL.Host, strings.TrimPrefix(chartURL.Path, "/"), nil
 }

--- a/operator/chartdownloader/s3_test.go
+++ b/operator/chartdownloader/s3_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func formatS3URL(bucket, object string) string {
+	return fmt.Sprintf("s3://%s/%s", bucket, object)
+}
+
 type mockS3 struct {
 	mock.Mock
 }
@@ -50,7 +54,7 @@ func TestChartDownloadSuccess(t *testing.T) {
 		w.WriteAt(chartBytes, 0)
 	})
 
-	outChart, err := dl.Download(ctx, fmt.Sprintf("s3://%s/%s", testBucket, testObject))
+	outChart, err := dl.Download(ctx, formatS3URL(testBucket, testObject))
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedChart, outChart)
@@ -71,7 +75,7 @@ func TestChartDownloadFailure(t *testing.T) {
 		Key:    aws.String(testObject),
 	}).Return(0, fmt.Errorf("some download error"))
 
-	_, err := dl.Download(ctx, fmt.Sprintf("s3://%s/%s", testBucket, testObject))
+	_, err := dl.Download(ctx, formatS3URL(testBucket, testObject))
 	assert.Error(t, err)
 	mockD.AssertExpectations(t)
 }
@@ -95,7 +99,7 @@ func TestInvalidChartBytes(t *testing.T) {
 		w.WriteAt(chartBytes, 0)
 	})
 
-	_, err := dl.Download(ctx, fmt.Sprintf("s3://%s/%s", testBucket, testObject))
+	_, err := dl.Download(ctx, formatS3URL(testBucket, testObject))
 	assert.Error(t, err)
 	mockD.AssertExpectations(t)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -26,8 +26,8 @@ import (
 	"ship-it-operator/controllers"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/helm/pkg/helm"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +49,6 @@ func init() {
 func main() {
 	var (
 		awsRegion            string
-		chartRepository      string
 		gracePeriod          time.Duration
 		metricsAddr          string
 		namespace            string
@@ -58,7 +57,6 @@ func main() {
 	)
 
 	flag.StringVar(&awsRegion, "aws-region", "", "The AWS region where the operator's chart repository is hosted")
-	flag.StringVar(&chartRepository, "chart-repository", "", "The URI of the chart repository used by the operator")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "default", "The cluster namespace where the operator will deploy releases")
 	flag.StringVar(&tillerAddr, "tiller-address", "", "The cluster address of the tiller service")
@@ -87,23 +85,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	providers := chartdownloader.ProviderFuncs{
-		S3Func: func() client.ConfigProvider {
-			return session
-		},
-	}
-
-	downloader, err := chartdownloader.New(chartRepository, providers)
-	if err != nil {
-		setupLog.Error(err, "unable to create chart downloader")
-		os.Exit(1)
+	// S3 is currently the only supported chart repository type
+	downloaders := map[string]chartdownloader.Interface{
+		"s3": chartdownloader.NewS3Downloader(s3manager.NewDownloader(session)),
 	}
 
 	reconciler := controllers.NewHelmReleaseReconciler(
 		ctrl.Log,
 		mgr.GetClient(),
 		helm.NewClient(helm.Host(tillerAddr)),
-		downloader,
+		chartdownloader.New(downloaders),
 		controllers.Namespace(namespace),
 		controllers.GracePeriod(gracePeriod),
 	)

--- a/operator/main.go
+++ b/operator/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// S3 is currently the only supported chart repository type
-	downloaders := map[string]chartdownloader.Interface{
+	downloaders := map[string]chartdownloader.ChartDownloader{
 		"s3": chartdownloader.NewS3Downloader(s3manager.NewDownloader(session)),
 	}
 


### PR DESCRIPTION
The chartdownloader was picking a chart repository at application start
up, instead of using the values from the HelmRelease being reconciled.
The S3 downloader now correctly parses the bucket and object from the
chart URL.