### PR TITLE
Fixup syncd/github chart downloader

### DIFF
--- a/internal/syncd/integrations/github/downloader.go
+++ b/internal/syncd/integrations/github/downloader.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	filepath "path"
 
 	"github.com/google/go-github/v26/github"
 	"github.com/pkg/errors"
@@ -40,7 +41,7 @@ func (d *downloader) BufferDirectory(ctx context.Context, repo, path, ref string
 
 		return []*chartutil.BufferedFile{
 			{
-				Name: file.GetName(),
+				Name: filepath.Join(path, file.GetName()),
 				Data: []byte(content),
 			},
 		}, nil

--- a/internal/syncd/integrations/github/downloader_test.go
+++ b/internal/syncd/integrations/github/downloader_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"path"
 	"testing"
 
 	"github.com/google/go-github/v26/github"
@@ -54,10 +55,10 @@ func TestBufferDirectorySingleFile(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Len(t, files, 1)
-		assert.Equal(t, files[0], &chartutil.BufferedFile{
-			Name: testFilename,
+		assert.Equal(t, &chartutil.BufferedFile{
+			Name: path.Join(testPath, testFilename),
 			Data: []byte(testContent),
-		})
+		}, files[0])
 	}
 }
 
@@ -114,19 +115,19 @@ func TestBufferDirectoryFlatDirectory(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Len(t, files, 3)
-		assert.EqualValues(t, files, []*chartutil.BufferedFile{
+		assert.EqualValues(t, []*chartutil.BufferedFile{
 			{
-				Name: testFilename1,
+				Name: path.Join(testPath1, testFilename1),
 				Data: []byte(testContent1),
 			},
 			{
-				Name: testFilename2,
+				Name: path.Join(testPath2, testFilename2),
 				Data: []byte(testContent2),
 			},
 			{
-				Name: testFilename3,
+				Name: path.Join(testPath3, testFilename3),
 				Data: []byte(testContent3),
 			},
-		})
+		}, files)
 	}
 }


### PR DESCRIPTION
The downloader needs to preserve the full path of the file. Before it
would only save the filename, so a file like `foo/bar/file.yaml` would
be given a filename `file.yaml`. However when downloading a chart, which
contains nested directories like `chart/templates/*.yaml`, we need to
preserve the full file path in order to load the chart correctly.