### PR TITLE
UI: Implement searching by release name, owning squad or status

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -65,7 +65,7 @@
 }
 
 .search-releases {
-  width: 250px;
+  width: 300px;
   margin-left: 24px;
 }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -64,6 +64,10 @@
   margin: auto;
 }
 
+.search-releases {
+  margin-left: 24px;
+}
+
 .kube-resource-list {
   display: flex;
   align-items: center;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -65,6 +65,7 @@
 }
 
 .search-releases {
+  width: 250px;
   margin-left: 24px;
 }
 

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -10,7 +10,7 @@ const API_ADDRESS = urljoin(window.location.protocol + '//' + window.location.ho
 class App extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {query: ""}
+    this.state = { query: "" }
     axios.get(urljoin(API_ADDRESS, 'releases')).then(response => {
       this.setState({data : response.data})
     })
@@ -19,7 +19,7 @@ class App extends React.Component {
   render() {
     return (
       <div className="App">
-        <TopBar onQueryChanged={q => this.setState({query: q})}/>
+        <TopBar onQueryChanged={ q => this.setState({ query: q }) }/>
         {
           this.state.data ?
           <ReactExpandableGrid

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -10,7 +10,7 @@ const API_ADDRESS = urljoin(window.location.protocol + '//' + window.location.ho
 class App extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {}
+    this.state = {query: ""}
     axios.get(urljoin(API_ADDRESS, 'releases')).then(response => {
       this.setState({data : response.data})
     })
@@ -19,7 +19,7 @@ class App extends React.Component {
   render() {
     return (
       <div className="App">
-        <TopBar />
+        <TopBar onQueryChanged={q => this.setState({query: q})}/>
         {
           this.state.data ?
           <ReactExpandableGrid
@@ -29,6 +29,7 @@ class App extends React.Component {
             cellSize={250}
             API_ADDRESS={API_ADDRESS}
             ExpandedDetail_closeX_bool={false}
+            query={this.state.query}
           /> : <CircularProgress />
         }
       </div>

--- a/web/src/components/TileGrid.js
+++ b/web/src/components/TileGrid.js
@@ -104,10 +104,19 @@ class ReactExpandableGrid extends React.Component {
     for (var i in gridData) {
       idCounter = idCounter + 1
       let thisUniqueKey = 'grid_cell_' + idCounter.toString()
-      grid.push(<SingleGridCell API_ADDRESS={this.props.API_ADDRESS} handleCellClick={this.handleCellClick.bind(this)} key={thisUniqueKey} id={thisUniqueKey} cellMargin={this.props.cellMargin} SingleGridCellData={gridData[i]} cellSize={this.props.cellSize} />)
+      if (this.matchesQuery(gridData[i], this.props.query)) {
+        grid.push(<SingleGridCell API_ADDRESS={this.props.API_ADDRESS} handleCellClick={this.handleCellClick.bind(this)} key={thisUniqueKey} id={thisUniqueKey} cellMargin={this.props.cellMargin} SingleGridCellData={gridData[i]} cellSize={this.props.cellSize} />)
+      }
     }
 
     return grid
+  }
+
+  matchesQuery(release, query) {
+    const fields = [release.name, release.owner.squad, release.status];
+    return fields
+      .map(f => f.toLowerCase())
+      .some(f => f.includes(query));
   }
 
   render() {

--- a/web/src/components/TileGrid.js
+++ b/web/src/components/TileGrid.js
@@ -105,7 +105,16 @@ class ReactExpandableGrid extends React.Component {
       idCounter = idCounter + 1
       let thisUniqueKey = 'grid_cell_' + idCounter.toString()
       if (this.matchesQuery(gridData[i], this.props.query)) {
-        grid.push(<SingleGridCell API_ADDRESS={this.props.API_ADDRESS} handleCellClick={this.handleCellClick.bind(this)} key={thisUniqueKey} id={thisUniqueKey} cellMargin={this.props.cellMargin} SingleGridCellData={gridData[i]} cellSize={this.props.cellSize} />)
+        grid.push(
+          <SingleGridCell
+            API_ADDRESS={this.props.API_ADDRESS}
+            handleCellClick={this.handleCellClick.bind(this)}
+            key={thisUniqueKey}
+            id={thisUniqueKey}
+            cellMargin={this.props.cellMargin}
+            SingleGridCellData={gridData[i]}
+            cellSize={this.props.cellSize} />
+        )
       }
     }
 

--- a/web/src/components/TopBar.js
+++ b/web/src/components/TopBar.js
@@ -26,7 +26,11 @@ class TopBar extends React.Component {
             </Typography>
             <div className="search-releases">
               <TextField
-                InputProps={{ type: "search" }}
+                fullWidth
+                InputProps={{
+                  type: "search",
+                  placeholder: "Search by name, squad or status",
+                }}
                 onChange={e => this.props.onQueryChanged(e.target.value)}
               />
             </div>

--- a/web/src/components/TopBar.js
+++ b/web/src/components/TopBar.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { AppBar, Toolbar, Typography } from '@material-ui/core'
 import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider'
 import IconButton from '@material-ui/core/IconButton'
+import InputAdornment from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField'
+import SearchIcon from '@material-ui/icons/Search';
 import ShipIcon from '../assets/passenger_ship.png'
 import * as constants from '../Constants'
 import * as themes from '../Themes'
@@ -30,6 +32,11 @@ class TopBar extends React.Component {
                 InputProps={{
                   type: "search",
                   placeholder: "Search by name, squad or status",
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  )
                 }}
                 onChange={e => this.props.onQueryChanged(e.target.value)}
               />

--- a/web/src/components/TopBar.js
+++ b/web/src/components/TopBar.js
@@ -3,9 +3,9 @@ import { AppBar, Toolbar, Typography } from '@material-ui/core'
 import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider'
 import IconButton from '@material-ui/core/IconButton'
 import InputAdornment from '@material-ui/core/InputAdornment';
-import TextField from '@material-ui/core/TextField'
 import SearchIcon from '@material-ui/icons/Search';
 import ShipIcon from '../assets/passenger_ship.png'
+import TextField from '@material-ui/core/TextField'
 import * as constants from '../Constants'
 import * as themes from '../Themes'
 
@@ -38,7 +38,7 @@ class TopBar extends React.Component {
                     </InputAdornment>
                   )
                 }}
-                onChange={e => this.props.onQueryChanged(e.target.value)}
+                onChange={ e => this.props.onQueryChanged(e.target.value) }
               />
             </div>
           </Toolbar>

--- a/web/src/components/TopBar.js
+++ b/web/src/components/TopBar.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { AppBar, Toolbar, Typography } from '@material-ui/core'
 import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider'
 import IconButton from '@material-ui/core/IconButton'
+import TextField from '@material-ui/core/TextField'
 import ShipIcon from '../assets/passenger_ship.png'
 import * as constants from '../Constants'
 import * as themes from '../Themes'
@@ -23,6 +24,12 @@ class TopBar extends React.Component {
             <Typography variant="h6">
               Ship-it!
             </Typography>
+            <div className="search-releases">
+              <TextField
+                InputProps={{ type: "search" }}
+                onChange={e => this.props.onQueryChanged(e.target.value)}
+              />
+            </div>
           </Toolbar>
         </AppBar>
       </MuiThemeProvider>


### PR DESCRIPTION
This PR adds a search bar in the top bar of the web UI which allows people to filter the list of releases by name, owning squad or status. It's implemented by a simple string `includes` on each field to check if any field contains the query.

After searching, pressing the `x` that appears on the right of the search bar (or pressing escape) will clear the query, showing all the releases again.

Since this is my first PR to this repo, let me know if I'm missing anything. I checked the tests for the web UI, and it looks like there's only one really basic test. If we're going to start adding tests, let me know and I can add some to this PR.


## Screenshots

![Screen Shot 2019-09-17 at 10 09 50 AM](https://user-images.githubusercontent.com/4354714/65049232-6f936180-d933-11e9-9806-d2d035c79b6d.png)
![Screen Shot 2019-09-17 at 10 09 55 AM](https://user-images.githubusercontent.com/4354714/65049233-6f936180-d933-11e9-890a-e5408adc80bf.png)
![Screen Shot 2019-09-17 at 10 10 01 AM](https://user-images.githubusercontent.com/4354714/65049234-6f936180-d933-11e9-8c67-76cd43993508.png)

VELO-1547