### PR TITLE
Bump golang version -> 1.13 in Travis & Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.1
+  - 1.13
 
 cache:
   directories:

--- a/cmd/ship-it-api/Dockerfile
+++ b/cmd/ship-it-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 AS golang-build
+FROM golang:1.13 AS golang-build
 WORKDIR /build
 COPY operator/go.mod operator/go.sum ./operator/
 COPY go.mod go.sum ./

--- a/cmd/ship-it-syncd/Dockerfile
+++ b/cmd/ship-it-syncd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 AS golang-build
+FROM golang:1.13 AS golang-build
 WORKDIR /build
 COPY operator/go.mod operator/go.sum ./operator/
 COPY go.mod go.sum ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
doesn't look like there's any issues, builds are green