### PR TITLE
Add stakater/reloader annotation to syncd deployment

### DIFF
--- a/deploy/ship-it/templates/syncd-deployment.yaml
+++ b/deploy/ship-it/templates/syncd-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ship-it.fullname" . }}-syncd
+  annotations:
+    {{ toYaml .Values.syncd.annotations | nindent 2 | trim }}
   labels:
     {{ include "ship-it.metadataLabels" . | nindent 2 | trim }}
 spec:

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -43,6 +43,9 @@ operator:
   enableLeaderElection: false
 
 syncd:
+  annotations:
+    reloader.stakater.com/auto: true
+
   image:
     repository: 723255503624.dkr.ecr.us-east-1.amazonaws.com/ship-it-syncd
     tag: latest


### PR DESCRIPTION
The reloader operator does a rolling deployment restart whenever one of
the secrets used by the deployment changes.

VELO-1542