### PR TITLE
Remove unused ecr image reconciler logger

### DIFF
--- a/cmd/ship-it-syncd/main.go
+++ b/cmd/ship-it-syncd/main.go
@@ -94,7 +94,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	imageReconciler := ecr.NewReconciler(logger, registryEditor, informer)
+	imageReconciler := ecr.NewReconciler(registryEditor, informer)
 
 	chartReconciler := github.NewReconciler(
 		helm.NewClient(helm.Host(cfg.TillerHost)),

--- a/internal/syncd/integrations/ecr/reconciler.go
+++ b/internal/syncd/integrations/ecr/reconciler.go
@@ -5,7 +5,6 @@ import (
 
 	"ship-it/internal/image"
 
-	"github.com/go-kit/kit/log"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -24,14 +23,12 @@ type ReleaseIndexer interface {
 type ImageReconciler struct {
 	editor  ChartEditor
 	indexer ReleaseIndexer
-	logger  log.Logger
 }
 
-func NewReconciler(l log.Logger, e ChartEditor, i ReleaseIndexer) *ImageReconciler {
+func NewReconciler(e ChartEditor, i ReleaseIndexer) *ImageReconciler {
 	return &ImageReconciler{
 		editor:  e,
 		indexer: i,
-		logger:  l,
 	}
 }
 

--- a/internal/syncd/integrations/ecr/reconciler_test.go
+++ b/internal/syncd/integrations/ecr/reconciler_test.go
@@ -7,7 +7,6 @@ import (
 
 	"ship-it/internal/image"
 
-	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,7 +33,7 @@ func (m *MockReleaseIndexer) Lookup(image *image.Ref) ([]types.NamespacedName, e
 func TestReconcileLookupFailure(t *testing.T) {
 	mockEditor := new(MockReleaseEditor)
 	mockIndexer := new(MockReleaseIndexer)
-	reconciler := NewReconciler(log.NewNopLogger(), mockEditor, mockIndexer)
+	reconciler := NewReconciler(mockEditor, mockIndexer)
 	inputImage := &image.Ref{
 		Registry:   "723255503624.dkr.ecr.us-east-1.amazonaws.com",
 		Repository: "bar",
@@ -53,7 +52,7 @@ func TestReconcilerUpdateFailure(t *testing.T) {
 	mockEditor := new(MockReleaseEditor)
 	mockIndexer := new(MockReleaseIndexer)
 
-	reconciler := NewReconciler(log.NewNopLogger(), mockEditor, mockIndexer)
+	reconciler := NewReconciler(mockEditor, mockIndexer)
 
 	inputImage := &image.Ref{
 		Registry:   "723255503624.dkr.ecr.us-east-1.amazonaws.com",
@@ -83,7 +82,7 @@ func TestReconcilerSuccess(t *testing.T) {
 	mockEditor := new(MockReleaseEditor)
 	mockIndexer := new(MockReleaseIndexer)
 
-	reconciler := NewReconciler(log.NewNopLogger(), mockEditor, mockIndexer)
+	reconciler := NewReconciler(mockEditor, mockIndexer)
 
 	inputImage := &image.Ref{
 		Registry:   "723255503624.dkr.ecr.us-east-1.amazonaws.com",


### PR DESCRIPTION
The reconciler doesn't use the logger, and ideally shouldn't ever need
to. Since the listener implementations have logging middleware, any
error returned normally by the reconciler will be logged after it
bubbles to the listener.