### PR TITLE
Reduce ship-it-api build time by caching more

### DIFF
--- a/cmd/ship-it-api/Dockerfile
+++ b/cmd/ship-it-api/Dockerfile
@@ -9,8 +9,10 @@ COPY operator/api ./operator/api
 RUN CGO_ENABLED=0 go build -o ship-it-api cmd/ship-it-api/main.go
 
 FROM node:12.3 AS node-build
+COPY web/package.json .
+RUN npm install
 COPY web .
-RUN npm install react-scripts && npm run build
+RUN npm run build
 
 FROM alpine:3.8
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
`npm install react-scripts` can take dozens of seconds to complete. The way it was written originally, any source code changes cause the layer that installs the scripts to be uncached. Re-organizing allows better re-use of cached layers and avoids re-downloading the same package during local dev.