### PR TITLE
Add ExternalSecret to ship-it chart

### DIFF
--- a/deploy/ship-it/Chart.yaml
+++ b/deploy/ship-it/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for ship-it
 name: ship-it
-version: 0.1.3
+version: 0.1.5

--- a/deploy/ship-it/templates/external-secret.yaml
+++ b/deploy/ship-it/templates/external-secret.yaml
@@ -3,6 +3,8 @@ kind: ExternalSecret
 apiVersion: kubernetes-client.io/v1
 metadata:
   name: {{ .Values.existingSecretName }}
+  labels:
+    {{ include "ship-it.metadataLabels" . | nindent 2 | trim }}
 spec:
   backendType: secretsManager
   dataFrom:

--- a/deploy/ship-it/templates/external-secret.yaml
+++ b/deploy/ship-it/templates/external-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.externalSecretName }}
+kind: ExternalSecret
+apiVersion: kubernetes-client.io/v1
+metadata:
+  name: {{ .Values.existingSecretName }}
+spec:
+  backendType: secretsManager
+  dataFrom:
+  - {{ .Values.externalSecretName }}
+{{- end }}

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -2,7 +2,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 awsRegion: us-east-1
-sslCertPath: /etc/ssl/certs/ca-certificates.crt
+sslCertPath: /etc/ssl/certs/ca-bundle.crt
 tillerAddress: tiller-deploy.kube-system.svc.cluster.local:44134
 
 iamRoleArn: arn:aws:iam::723255503624:role/ship-it-prod-v4

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -2,11 +2,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 awsRegion: us-east-1
-existingSecretName: ship-it
 sslCertPath: /etc/ssl/certs/ca-certificates.crt
 tillerAddress: tiller-deploy.kube-system.svc.cluster.local:44134
 
 iamRoleArn: arn:aws:iam::723255503624:role/ship-it-prod-v4
+
+externalSecretName: prod-v3/default/ship-it
+existingSecretName: ship-it
 
 useDogstatsdHostIP: true
 


### PR DESCRIPTION
We should eventually de-wattpad the chart's default values and configure it all in miranda. I commented something about this on VELO-1589 in jira. Then we could have a `prod-v3/values.yaml` without external secret, and a `prod-v4/values.yaml` using external secret.