### PR TITLE
ship-it-operator controller namespace scopes

### DIFF
--- a/deploy/ship-it/Chart.yaml
+++ b/deploy/ship-it/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for ship-it
 name: ship-it
-version: 0.1.7
+version: 0.1.8

--- a/deploy/ship-it/templates/operator-deployment.yaml
+++ b/deploy/ship-it/templates/operator-deployment.yaml
@@ -34,7 +34,9 @@ spec:
             - {{ .Values.tillerAddress }}
             - --aws-region
             - {{ .Values.awsRegion }}
-            - --namespace
+            - --target-namespace
+            - {{ .Values.operator.targetNamespace }}
+            - --watch-namespace
             - {{ .Release.Namespace }}
             - --grace-period
             - {{ .Values.operator.gracePeriod }}

--- a/deploy/ship-it/values.yaml
+++ b/deploy/ship-it/values.yaml
@@ -59,6 +59,7 @@ operator:
   gracePeriod: 10s
   metricsPort: 8080
   enableLeaderElection: false
+  targetNamespace: "default"
 
 syncd:
   annotations: {}

--- a/operator/main.go
+++ b/operator/main.go
@@ -70,6 +70,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
+		Namespace:          namespace,
 		LeaderElection:     enableLeaderElection,
 	})
 	if err != nil {


### PR DESCRIPTION
The operator is logging errors because it's not permitted to list resources at a cluster scope. I realized the `controllers.Namespace` option I had set previously controls which namespace tiller deploys into, not where the operator is watching for HelmRelease resources, so we need 2 different arguments.