### PR TITLE
Speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
   include:
     - stage: Test and Lint
       name: Go and Codecov
-      install: GO111MODULE=off go get "github.com/golangci/golangci-lint/cmd/golangci-lint"
+      install: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
       script:
         - golangci-lint --deadline=5m run -D errcheck -E goimports -E interfacer -E scopelint ./...
         - go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,15 +46,6 @@ jobs:
       name: JavaScript
       script: cd web && npm install -D && npm run lint && npm run test
 
-    - stage: Test and Lint
-      name: Helm Lint
-      script:
-        - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-        - chmod 700 get_helm.sh && sudo ./get_helm.sh
-        - helm init --client-only
-        - helm lint deploy/ship-it
-        - helm lint deploy/localstack
-
     - stage: Push
       name: Push
       install: pip install --user awscli
@@ -64,6 +55,8 @@ jobs:
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh && sudo ./get_helm.sh
         - helm init --client-only
+        - helm lint deploy/ship-it
+        - helm lint deploy/localstack
         - helm plugin install https://github.com/hypnoglow/helm-s3.git
       script:
         - helm repo add wattpad s3://charts.wattpadhq.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,15 @@ jobs:
       name: JavaScript
       script: cd web && npm install -D && npm run lint && npm run test
 
+    - stage: Test and Lint
+      name: Helm Lint
+      script:
+        - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+        - chmod 700 get_helm.sh && sudo ./get_helm.sh
+        - helm init --client-only
+        - helm lint deploy/ship-it
+        - helm lint deploy/localstack
+
     - stage: Push
       name: Push
       install: pip install --user awscli
@@ -55,8 +64,6 @@ jobs:
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh && sudo ./get_helm.sh
         - helm init --client-only
-        - helm lint deploy/ship-it
-        - helm lint deploy/localstack
         - helm plugin install https://github.com/hypnoglow/helm-s3.git
       script:
         - helm repo add wattpad s3://charts.wattpadhq.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ stages:
 jobs:
   include:
     - stage: Test and Lint
-      name: Go and Codecov
+      name: Go
       install: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
       script:
         - golangci-lint --deadline=5m run -D errcheck -E goimports -E interfacer -E scopelint ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,39 @@ services:
   - docker
 
 stages:
-  - name: Test and Lint
+  - name: Lint
+    if: type = pull_request
+  - name: Test and Build
     if: type = pull_request
   - name: Push
     if: type = push AND branch = master
 
 jobs:
   include:
-    - stage: Test and Lint
+    - stage: Lint
       name: Go
       install: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      script: golangci-lint --deadline=5m run -D errcheck -E goimports -E interfacer -E scopelint ./...
+
+    - stage: Lint
+      name: Helm
+      install:
+        - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+        - chmod 700 get_helm.sh && sudo ./get_helm.sh
       script:
-        - golangci-lint --deadline=5m run -D errcheck -E goimports -E interfacer -E scopelint ./...
+        - helm init --client-only
+        - helm lint deploy/ship-it
+        - helm lint deploy/localstack
+
+    - stage: Test and Build
+      name: Go
+      script:
         - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
         - TARGET=ship-it-api make build
         - TARGET=ship-it-syncd make build
       after_success: bash <(curl -s https://codecov.io/bash)
 
-    - stage: Test and Lint
+    - stage: Test and Build
       name: Operator
       before_script:
         - curl -sL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz | tar -xz -C /tmp/
@@ -42,18 +57,9 @@ jobs:
         - make test
         - make docker-build
 
-    - stage: Test and Lint
+    - stage: Test and Build
       name: JavaScript
       script: cd web && npm install -D && npm run lint && npm run test
-
-    - stage: Test and Lint
-      name: Helm Lint
-      script:
-        - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-        - chmod 700 get_helm.sh && sudo ./get_helm.sh
-        - helm init --client-only
-        - helm lint deploy/ship-it
-        - helm lint deploy/localstack
 
     - stage: Push
       name: Push

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,34 +16,20 @@ services:
 stages:
   - name: Test and Lint
     if: type = pull_request
-  - name: Build
-    if: type = pull_request
   - name: Push
     if: type = push AND branch = master
-  - name: Codecov
-    if: type = pull_request
 
 jobs:
   include:
-    - stage: Build
-      name: Docker
-      script:
-        - TARGET=ship-it-api make build
-        - TARGET=ship-it-syncd make build
-    
-    - stage: Build
-      name: Operator
-      before_script:
-        - cd operator
-      script:
-        - make docker-build
-
     - stage: Test and Lint
-      name: Go
+      name: Go and Codecov
       install: GO111MODULE=off go get "github.com/golangci/golangci-lint/cmd/golangci-lint"
       script:
         - golangci-lint --deadline=5m run -D errcheck -E goimports -E interfacer -E scopelint ./...
-        - go test ./...
+        - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        - TARGET=ship-it-api make build
+        - TARGET=ship-it-syncd make build
+      after_success: bash <(curl -s https://codecov.io/bash)
 
     - stage: Test and Lint
       name: Operator
@@ -54,6 +40,7 @@ jobs:
         - cd operator
       script:
         - make test
+        - make docker-build
 
     - stage: Test and Lint
       name: JavaScript
@@ -84,11 +71,6 @@ jobs:
         - TARGET=ship-it-api make push
         - TARGET=ship-it-syncd make push
         - cd operator && make docker-push
-
-    - stage: Codecov
-      name: Test Coverage Report
-      script: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-      after_success: bash <(curl -s https://codecov.io/bash)
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build docs jsonschema push
 
-CHART_VERSION := $(shell helm inspect deploy/ship-it | awk '/version/{ print $$2; }')
-CHART_REPOSITORY := $(shell helm repo list | awk '/wattpad/{ print $$1; }')
+CHART_VERSION = $(shell helm inspect deploy/ship-it | awk '/version/{ print $$2; }')
+CHART_REPOSITORY = $(shell helm repo list | awk '/wattpad/{ print $$1; }')
 
 REGISTRY := 723255503624.dkr.ecr.us-east-1.amazonaws.com
 VERSION := $(shell git rev-parse HEAD)


### PR DESCRIPTION
Cuts build time from 12 minutes to roughly 7.5 minutes

- Build stage jobs run immediately after testing jobs so it re-uses cached packages
- Codecov to run in Test and Lint stage so we aren't running `go test` twice
- Use recommended and faster method for installing golangci-lint

VELO-1771