### PR TITLE
Fix GetRelease endpoint

### DIFF
--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -19,7 +19,7 @@ type ResourcesGetter interface {
 
 func New(rl ReleaseLister, rg ResourcesGetter) *Service {
 	return &Service{
-		Namespace: v1.NamespaceAll,
+		Namespace: v1.NamespaceDefault,
 		releases:  rl,
 		resources: rg,
 	}


### PR DESCRIPTION
There was an error of `an empty namespace may not be set when a resource name is provided` when calling `curl -i localhost:31901/api/releases/my-service-name`. This sets the namespace for new services to be `default` instead of empty.