### PR TITLE
Handle "no affected registered releases" edge case in ECR reconciler

### DIFF
--- a/internal/syncd/integrations/ecr/chart_editor_test.go
+++ b/internal/syncd/integrations/ecr/chart_editor_test.go
@@ -2,6 +2,7 @@ package ecr
 
 import (
 	"context"
+	"encoding/base64"
 	"path"
 	"testing"
 
@@ -83,27 +84,27 @@ func TestEdit(t *testing.T) {
 
 	treeEntries := append(unmodifiedTreeEntries, modifiedTreeEntries...)
 
-	blobContents := []string{
-		`kind: HelmRelease
+	blobContents := [][]byte{
+		[]byte(`kind: HelmRelease
 apiVersion: shipit.wattpad.com/v1beta1
 metadata:
     name: foo-release
 spec:
     values:
-	image:
-	    repository: hub.docker.com/foo,
-	    tag: fooreleaseoldtag
-`,
-		`kind: HelmRelease
+        image:
+            repository: hub.docker.com/foo,
+            tag: fooreleaseoldtag
+`),
+		[]byte(`kind: HelmRelease
 apiVersion: shipit.wattpad.com/v1beta1
 metadata:
     name: bar-release
 spec:
     values:
-	image:
-	    repository: hub.docker.com/bar,
-	    tag: barreleaseoldtag
-`,
+        image:
+            repository: hub.docker.com/bar,
+            tag: barreleaseoldtag
+`),
 	}
 
 	releases := []types.NamespacedName{
@@ -151,9 +152,10 @@ spec:
 
 	// expect GetBlob per changed file
 	for i, entry := range modifiedTreeEntries {
+		blob64 := base64.StdEncoding.EncodeToString(blobContents[i])
 		mockGit.On("GetBlob", ctx, testOrg, testRepo, entry.GetSHA()).Return(
 			&github.Blob{
-				Content: github.String(blobContents[i]),
+				Content: github.String(blob64),
 			}, &github.Response{}, nil,
 		)
 	}

--- a/internal/syncd/integrations/ecr/listener.go
+++ b/internal/syncd/integrations/ecr/listener.go
@@ -77,6 +77,14 @@ func (l *ImageListener) handler(r syncd.ImageReconciler) sqsconsumer.MessageHand
 			return nil
 		}
 
-		return r.Reconcile(ctx, &image)
+		err := r.Reconcile(ctx, &image)
+		if errors.Cause(err) == errNoRegisteredReleasesAffected {
+			// if no releases were affected by the new image, then
+			// the event was successfully handled. Log it to be able
+			// to detect when syncd successfully does nothing.
+			l.logger.Log("info", err.Error())
+			return nil
+		}
+		return err
 	}
 }

--- a/internal/syncd/integrations/ecr/listener_test.go
+++ b/internal/syncd/integrations/ecr/listener_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/discard"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -71,9 +72,44 @@ func TestECRHandler(t *testing.T) {
 	"repositoryName": "monolith-php", 
 	"tag": "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
 	"registryId": "723255503624"
-}
-`
+}`
 	err = testListener.handler(mockReconciler)(context.Background(), inputJSON)
 	assert.NoError(t, err)
 	mockReconciler.AssertExpectations(t)
+}
+
+type mockLogger struct {
+	mock.Mock
+}
+
+func (m *mockLogger) Log(kvs ...interface{}) error {
+	args := m.Called(kvs...)
+	return args.Error(0)
+}
+
+func TestReconcilerNoRegisteredReleasesAffected(t *testing.T) {
+	testErr := errors.Wrap(errNoRegisteredReleasesAffected, "wrapping with test context")
+
+	mockLogger := new(mockLogger)
+	mockLogger.On("Log", mock.AnythingOfType("string"), testErr.Error()).Return(nil)
+
+	testListener := &ImageListener{
+		logger: mockLogger,
+		timer:  discard.NewHistogram(),
+	}
+
+	inputJSON := `
+{
+	"eventTime": "2019-07-11T14:19:59Z", 
+	"repositoryName": "monolith-php", 
+	"tag": "78bc9ccf64eb838c6a0e0492ded722274925e2bd",
+	"registryId": "723255503624"
+}`
+
+	mockReconciler := new(MockReconciler)
+	mockReconciler.On("Reconcile", mock.Anything, mock.Anything).Return(testErr)
+
+	err := testListener.handler(mockReconciler)(context.Background(), inputJSON)
+	assert.NoError(t, err)
+	mockLogger.AssertExpectations(t)
 }


### PR DESCRIPTION
If a new image is pushed but there are no registered releases that use
the image, the chart editor can exit early with a meaningful error
message. The error message can be logged so we can see what syncd is
doing even when there aren't many services registered.

---

I'm realizing there's a bit of ugliness in the way ship-it tracks the state of the registry chart right now. Most of the time the state of the registry chart release in the cluster is the source of truth, but this logic uses the state of the registry chart in github. 

Though those 2 states will eventually converge, it's possible that they differ at the moment ship-it observes them. I can't think of a concrete case where this actually causes problems, but I'm probably not being creative enough.